### PR TITLE
abstract out generic execution functions

### DIFF
--- a/raptiformica/shell/cjdns.py
+++ b/raptiformica/shell/cjdns.py
@@ -2,7 +2,8 @@ from os import path
 from logging import getLogger
 
 from raptiformica.settings import INSTALL_DIR, RAPTIFORMICA_DIR
-from raptiformica.shell.execute import raise_failure_factory, run_command_remotely_print_ready
+from raptiformica.shell.execute import run_critical_unbuffered_command_remotely_print_ready, \
+    run_remote_multiple_labeled_commands
 from raptiformica.shell.git import ensure_latest_source
 
 CJDNS_REPOSITORY = "https://github.com/cjdelisle/cjdns.git"
@@ -28,16 +29,11 @@ def ensure_cjdns_dependencies(host, port=22):
                    'apt-get install -yy nodejs '
                    'build-essential git python) || /bin/true"')
     )
-    for d, command_as_string in ensure_cjdns_dependencies_commands:
-        run_command_remotely_print_ready(
-            ["sh", "-c", command_as_string],
-            host, port=port,
-            failure_callback=raise_failure_factory(
-                "Failed to run (if {}) install cjdns "
-                "dependencies command".format(d)
-            ),
-            buffered=False
-        )
+    run_remote_multiple_labeled_commands(
+        ensure_cjdns_dependencies_commands, host, port=port,
+        failure_message="Failed to run (if {}) install cjdns "
+                        "dependencies command"
+    )
 
 
 def cjdns_setup(host, port=22):
@@ -57,13 +53,10 @@ def cjdns_setup(host, port=22):
             cjdns_checkout_directory, setup_script,
         )
     ]
-    exit_code, _, _ = run_command_remotely_print_ready(
-        cjdns_setup_command,
-        host, port=port,
-        failure_callback=raise_failure_factory(
-            "Failed to ensure that CJDNS was built, configured and installed"
-        ),
-        buffered=False
+    exit_code, _, _ = run_critical_unbuffered_command_remotely_print_ready(
+        cjdns_setup_command, host, port=port,
+        failure_message="Failed to ensure that CJDNS was built, "
+                        "configured and installed"
     )
     return exit_code
 

--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
-from raptiformica.shell.execute import raise_failure_factory
-from raptiformica.shell.execute import run_command_remotely_print_ready
+from raptiformica.shell.execute import run_critical_unbuffered_command_remotely_print_ready, \
+    run_remote_multiple_labeled_commands
 
 log = getLogger(__name__)
 
@@ -25,16 +25,11 @@ def ensure_consul_dependencies(host, port=22):
                    '(apt-get update -yy && '
                    'apt-get install -yy wget unzip) || /bin/true"')
     )
-    for d, command_as_string in ensure_consul_dependencies_commands:
-        run_command_remotely_print_ready(
-            ["sh", "-c", command_as_string],
-            host, port=port,
-            failure_callback=raise_failure_factory(
-                "Failed to run (if {}) install consul "
-                "dependencies command".format(d)
-            ),
-            buffered=False
-        )
+    run_remote_multiple_labeled_commands(
+        ensure_consul_dependencies_commands, host, port=port,
+        failure_message="Failed to run (if {}) install consul "
+                        "dependencies command"
+    )
 
 
 def ensure_latest_consul_release(host, port=22):
@@ -46,13 +41,9 @@ def ensure_latest_consul_release(host, port=22):
     """
     log.info("Ensuring consul release {} is on disk "
              "on the remote machine".format(CONSUL_RELEASE.split('/')[-1]))
-    run_command_remotely_print_ready(
-        ['wget', '-nc', CONSUL_RELEASE],
-        host, port=port,
-        failure_callback=raise_failure_factory(
-            "Failed to retrieve latest consul release"
-        ),
-        buffered=False
+    run_critical_unbuffered_command_remotely_print_ready(
+        ['wget', '-nc', CONSUL_RELEASE], host, port=port,
+        failure_message="Failed to retrieve latest consul release"
     )
 
 
@@ -64,14 +55,9 @@ def unzip_consul_release(host, port=22):
     :return None:
     """
     log.info("Making sure the consul binary is placed in /usr/bin")
-    run_command_remotely_print_ready(
-        ['unzip', '-o', CONSUL_RELEASE.split('/')[-1],
-         '-d', '/usr/bin'],
-        host, port=port,
-        failure_callback=raise_failure_factory(
-            "Failed to unzip latest consul release"
-        ),
-        buffered=False
+    run_critical_unbuffered_command_remotely_print_ready(
+        ['unzip', '-o', CONSUL_RELEASE.split('/')[-1], '-d', '/usr/bin'],
+        host, port=port, failure_message="Failed to retrieve latest consul release"
     )
 
 

--- a/raptiformica/shell/execute.py
+++ b/raptiformica/shell/execute.py
@@ -210,3 +210,67 @@ def run_command_remotely_print_ready(command_as_list, host, port=22,
         failure_callback=print_ready_callback_factory(failure_callback),
         buffered=buffered
     )
+
+
+def run_critical_command_remotely_print_ready(command_as_list, host, port=22, buffered=True,
+                                              failure_message='Command failed'):
+    """
+    A wrapper around run_command_print_ready but with a failure callback specified.
+    :param list command_as_list: The command as a list. I.e. ['/bin/ls', '/root']
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :param str failure_message: message to include in the raised failure
+    if the exit code is nonzero
+    :param bool buffered: Store output in a variable instead of printing it live
+    :return tuple process_output (exit code, standard out, standard error):
+    """
+    return run_command_remotely_print_ready(
+        command_as_list,
+        host, port=port,
+        failure_callback=raise_failure_factory(
+            failure_message
+        ),
+        buffered=buffered
+    )
+
+
+def run_critical_unbuffered_command_remotely_print_ready(command_as_list, host, port=22,
+                                                         failure_message='Command failed'):
+    """
+    Wrapper around run_critical_command_remotely_print_ready but with output to
+    standard out instead of capturing it.
+    :param list command_as_list: The command as a list. I.e. ['/bin/ls', '/root']
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :param str failure_message: message to include in the raised failure
+    if the exit code is nonzero
+    :param bool buffered: Store output in a variable instead of printing it live
+    :return tuple process_output (exit code, standard out, standard error):
+    """
+    return run_critical_command_remotely_print_ready(
+        command_as_list, host, port=port,
+        failure_message=failure_message,
+        buffered=False
+    )
+
+
+def run_remote_multiple_labeled_commands(distro_command_iterable, host, port=22,
+                                         failure_message='Command failed for label {}'):
+    """
+    Takes a iterable of iterables with label and command_as_string and runs the
+    command remotely and unbuffered, raising an error if it fails.
+
+
+    :param iterable[iterable] distro_command_iterable: iterable of pairs containing
+    label and a command as string
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :param str failure_message: message to include in the raised failure
+    if the exit code is nonzero. Should contain a {} to format the label.
+    :return None
+    """
+    for label, command_as_string in distro_command_iterable:
+        run_critical_unbuffered_command_remotely_print_ready(
+            ["sh", "-c", command_as_string], host, port=port,
+            failure_message=failure_message.format(label)
+        )


### PR DESCRIPTION
run_remote_multiple_labeled_commands and run_critical_unbuffered_command_remotely_print_ready
