### PR TITLE
screen is consul dep so we can detach during join

### DIFF
--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -22,10 +22,10 @@ def ensure_consul_dependencies(host, port=22):
 
     ensure_consul_dependencies_commands = (
         ('archlinux', '"type pacman 1> /dev/null && '
-                      'pacman -S --noconfirm wget unzip --needed || /bin/true"'),
+                      'pacman -S --noconfirm wget unzip screen --needed || /bin/true"'),
         ('debian', '"type apt-get 1> /dev/null && '
                    '(apt-get update -yy && '
-                   'apt-get install -yy wget unzip) || /bin/true"')
+                   'apt-get install -yy wget unzip screen) || /bin/true"')
     )
     run_remote_multiple_labeled_commands(
         ensure_consul_dependencies_commands, host, port=port,

--- a/raptiformica/shell/execute.py
+++ b/raptiformica/shell/execute.py
@@ -57,6 +57,7 @@ def execute_process(command, buffered=True, shell=False):
     :param list | str command: The command as a list or as string (when shell).
     I.e. ['/bin/ls', '/root'] or "/bin/ls /root"
     :param bool buffered: Store output in a variable instead of printing it live
+    :param bool shell: Run the command as in a shell and treat the command as a string instead of a list
     :return tuple (exit code, standard out, standard error):
     """
     log.debug("Running command: {}".format(command))

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
@@ -24,7 +24,7 @@ class TestEnsureConsulDependencies(TestCase):
             "sh", "-c",
             '"type pacman 1> /dev/null '
             '&& pacman -S --noconfirm '
-            'wget unzip --needed || /bin/true"'
+            'wget unzip screen --needed || /bin/true"'
         ], buffered=False, shell=False)
         expected_debian_call = call([
             '/usr/bin/env', 'ssh',
@@ -35,7 +35,7 @@ class TestEnsureConsulDependencies(TestCase):
             '"type apt-get 1> /dev/null && '
             '(apt-get update -yy && '
             'apt-get install -yy '
-            'wget unzip) || /bin/true"'
+            'wget unzip screen) || /bin/true"'
         ], buffered=False, shell=False)
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_installed.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_installed.py
@@ -8,6 +8,7 @@ class TestEnsureConsulInstalled(TestCase):
         self.ensure_latest_consul_release = self.set_up_patch('raptiformica.shell.consul.ensure_latest_consul_release')
         self.ensure_consul_dependencies = self.set_up_patch('raptiformica.shell.consul.ensure_consul_dependencies')
         self.unzip_consul_release = self.set_up_patch('raptiformica.shell.consul.unzip_consul_release')
+        self.consul_setup = self.set_up_patch('raptiformica.shell.consul.consul_setup')
 
     def test_ensure_consul_installed_ensure_latest_consul_release(self):
         ensure_consul_installed('1.2.3.4', port=2222)
@@ -23,3 +24,8 @@ class TestEnsureConsulInstalled(TestCase):
         ensure_consul_installed('1.2.3.4', port=2222)
 
         self.unzip_consul_release.assert_called_once_with('1.2.3.4', port=2222)
+
+    def test_ensure_consul_installed_runs_consul_setup(self):
+        ensure_consul_installed('1.2.3.4', port=2222)
+
+        self.consul_setup.assert_called_once_with('1.2.3.4', port=2222)


### PR DESCRIPTION
not all hosts are guaranteed to have an init system, and we need to
detach from the initial agent in order to join new machines into the
network
