### PR TITLE
start meshing services detached in a screen

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_enough_neighbours.py
+++ b/tests/unit/raptiformica/actions/mesh/test_enough_neighbours.py
@@ -1,4 +1,3 @@
-from mock import Mock
 from raptiformica.actions.mesh import enough_neighbours
 from tests.testcase import TestCase
 

--- a/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
@@ -1,0 +1,33 @@
+from raptiformica.actions.mesh import start_detached_cjdroute, CJDROUTE_CONF_PATH
+from tests.testcase import TestCase
+
+
+class TestStartDetachedCjdroute(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.execute_process = self.set_up_patch(
+                'raptiformica.shell.execute.execute_process'
+        )
+        self.process_output = (0, 'standard out output', '')
+        self.execute_process.return_value = self.process_output
+
+    def test_start_detached_cjdroute_logs_starting_detached_cjdroute_message(self):
+        start_detached_cjdroute()
+
+        self.log.info.assert_called_once_with("Starting cjdroute in the background")
+
+    def test_start_detached_cjdroute_starts_detached_cjdroute(self):
+        start_detached_cjdroute()
+
+        expected_command = "/usr/bin/env screen -d -m bash -c 'cat {} | cjdroute --nobg'".format(CJDROUTE_CONF_PATH)
+        self.execute_process.assert_called_once_with(
+            expected_command,
+            shell=True,
+            buffered=False
+        )
+
+    def test_start_detached_cjdroute_raises_error_when_starting_detached_cjdroute_failed(self):
+        process_output = (1, 'standard out output', 'standard error output')
+        self.execute_process.return_value = process_output
+        with self.assertRaises(RuntimeError):
+            start_detached_cjdroute()

--- a/tests/unit/raptiformica/actions/mesh/test_start_detached_consul_agent.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_detached_consul_agent.py
@@ -1,0 +1,33 @@
+from raptiformica.actions.mesh import start_detached_consul_agent, CJDROUTE_CONF_PATH
+from tests.testcase import TestCase
+
+
+class TestStartDetachedConsulAgent(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.execute_process = self.set_up_patch(
+                'raptiformica.shell.execute.execute_process'
+        )
+        self.process_output = (0, 'standard out output', '')
+        self.execute_process.return_value = self.process_output
+
+    def test_start_detached_consul_agent_logs_starting_detached_consul_agent_message(self):
+        start_detached_consul_agent()
+
+        self.log.info.assert_called_once_with("Starting a detached consul agent")
+
+    def test_start_detached_consul_agent_starts_detached_consul_agent(self):
+        start_detached_consul_agent()
+
+        expected_command = "/usr/bin/env screen -d -m /usr/bin/consul agent --config-dir /etc/consul.d/"
+        self.execute_process.assert_called_once_with(
+            expected_command,
+            shell=True,
+            buffered=False
+        )
+
+    def test_start_detached_consul_agent_raises_error_when_starting_detached_consul_agent_failed(self):
+        process_output = (1, 'standard out output', 'standard error output')
+        self.execute_process.return_value = process_output
+        with self.assertRaises(RuntimeError):
+            start_detached_consul_agent()

--- a/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
@@ -1,0 +1,25 @@
+from raptiformica.actions.mesh import start_meshing_services
+from tests.testcase import TestCase
+
+
+class TestStartMeshingServices(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.start_detached_cjdroute = self.set_up_patch('raptiformica.actions.mesh.start_detached_cjdroute')
+        self.start_detached_consul_agent = self.set_up_patch('raptiformica.actions.mesh.start_detached_consul_agent')
+
+    def test_start_meshing_services_logs_meshing_services_message(self):
+        start_meshing_services()
+
+        self.log.info.assert_called_once_with("Starting meshing services")
+
+    def test_start_meshing_services_starts_detached_cjdroute(self):
+        start_meshing_services()
+
+        self.start_detached_cjdroute.assert_called_once_with()
+
+    def test_start_meshing_services_starts_detached_consul_agent(self):
+        start_meshing_services()
+
+        self.start_detached_consul_agent.assert_called_once_with()
+


### PR DESCRIPTION
initially becaue this code path is also used to provision contains without an init system (Docker in this case) so we can't just start the services with service or systemctl. Instead always initially start the meshing services in detached screens and then whenever a machine with an init system reboots, the service file will be used.
