### PR TITLE
remove machine from mutable config when cleaned

### DIFF
--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 
 from raptiformica.settings import EPHEMERAL_DIR, MACHINES_DIR, MUTABLE_CONFIG
 from raptiformica.settings.load import load_config
+from raptiformica.settings.meshnet import ensure_neighbour_removed_from_config
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type, \
     retrieve_compute_type_config_for_server_type, get_compute_types, get_server_types, \
     verify_server_type_implemented_in_compute_type
@@ -168,6 +169,8 @@ def fire_clean_up_triggers(clean_up_triggers):
         if check_if_instance_is_stale(directory, detect_stale_instance_command):
             clean_up_stale_instance(directory, clean_up_stale_instance_command)
             rmtree(directory, ignore_errors=True)
+            uuid = directory.split('/')[-1]
+            ensure_neighbour_removed_from_config(uuid)
 
 
 def prune_local_machines():

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -42,17 +42,18 @@ def provision_machine(host, port=22, server_type=get_first_server_type()):
     run_configured_bootstrap_command(command, name, host, port=port)
 
 
-def assimilate_machine(host, port=22):
+def assimilate_machine(host, port=22, uuid=None):
     """
     Prepare the machine to be joined into the distributed network
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param str uuid: identifier for a local compute checkout
     :return None:
     """
     log.info("Preparing to machine to be joined into the distributed network")
     ensure_cjdns_installed(host, port=port)
     ensure_consul_installed(host, port=port)
-    update_meshnet_config(host, port=port)
+    update_meshnet_config(host, port=port, uuid=uuid)
 
 
 def deploy_meshnet(host, port=22):
@@ -68,7 +69,7 @@ def deploy_meshnet(host, port=22):
     mesh(host, port=port)
 
 
-def slave_machine(host, port=22, provision=True, assimilate=True, server_type=get_first_server_type()):
+def slave_machine(host, port=22, provision=True, assimilate=True, server_type=get_first_server_type(), uuid=None):
     """
     Provision the remote machine and optionally (default yes) assimilate it into the network.
     :param str host: hostname or ip of the remote machine
@@ -76,6 +77,7 @@ def slave_machine(host, port=22, provision=True, assimilate=True, server_type=ge
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
     :param str server_type: name of the server type to provision the machine as
+    :param str uuid: identifier for a local compute checkout
     :return None:
     """
     log.info("Slaving machine {}".format(host))
@@ -83,5 +85,5 @@ def slave_machine(host, port=22, provision=True, assimilate=True, server_type=ge
         provision_machine(host, port=port, server_type=server_type)
     upload_self(host, port=port)
     if assimilate:
-        assimilate_machine(host, port=port)
+        assimilate_machine(host, port=port, uuid=uuid)
         deploy_meshnet(host, port=port)

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -1,8 +1,6 @@
 from logging import getLogger
 
 from raptiformica.actions.slave import slave_machine
-from raptiformica.settings import MUTABLE_CONFIG
-from raptiformica.settings.load import load_config
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type, \
     retrieve_compute_type_config_for_server_type
 from raptiformica.shell.compute import start_instance
@@ -43,7 +41,7 @@ def start_compute_type(server_type=get_first_server_type(), compute_type=get_fir
     Start a compute instance of type server_type based on the config
     :param str server_type: name of the server type to provision the machine as
     :param str compute_type: name of the compute type to start an instance on
-    :return tuple connection_information: host and port
+    :return tuple compute_checkout_information: compute_checkout_uuid, host and port
     """
     source, boot_command, hostname_command, port_command = retrieve_start_instance_config(
         server_type=server_type, compute_type=compute_type
@@ -69,12 +67,13 @@ def spawn_machine(provision=False, assimilate=False, server_type=get_first_serve
         server_type, compute_type
     ))
     verify_ssh_agent_running()
-    host, port = start_compute_type(
+    uuid, host, port = start_compute_type(
         server_type=server_type, compute_type=compute_type
     )
     slave_machine(
         host, port=port,
         assimilate=assimilate,
         provision=provision,
-        server_type=server_type
+        server_type=server_type,
+        uuid=uuid
     )

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -9,6 +9,13 @@ log = getLogger(__name__)
 
 
 def ensure_shared_secret(config, service):
+    """
+    Ensure a key 'password' exists in the config for a specific meshnet service.
+    If no key exists, create it with a new (psuedo) random value
+    :param dict config: the config as found in mutable_config.json
+    :param str service: name of the service to ensure a secret for
+    :return dict config: the mutated config
+    """
     shared_secret = config['meshnet'][service].get(
         'password') or uuid.uuid4().hex
     config['meshnet'][service]['password'] = shared_secret
@@ -16,17 +23,38 @@ def ensure_shared_secret(config, service):
 
 
 def update_cjdns_config(config):
+    """
+    Ensure a key 'password' exists in the config for the cjdns item in the meshnet config
+    If no key exists, create it with a new (psuedo) random value
+    :param dict config: the config as found in mutable_config.json
+    :return dict config: the mutated config
+    """
     return ensure_shared_secret(config, 'cjdns')
 
 
 def update_consul_config(config):
+    """
+    Ensure a key 'password' exists in the config for the consul item in the meshnet config
+    If no key exists, create it with a new (psuedo) random value
+    :param dict config: the config as found in mutable_config.json
+    :return dict config: the mutated config
+    """
     return ensure_shared_secret(config, 'consul')
 
 
-def update_neighbours_config(config, host, port=22):
+def update_neighbours_config(config, host, port=22, uuid=None):
+    """
+    Update the neighbours config in the mutable_config
+    :param dict config: the config as found in mutable_config.json
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :param str uuid: identifier for a local compute checkout
+    :return dict config: the mutated config
+    """
     cjdns_public_key = cjdns.get_public_key(host, port=port)
     cjdns_ipv6_address = cjdns.get_ipv6_address(host, port=port)
-    config['meshnet']['neighbours'][cjdns_public_key] = {
+
+    neighbour_config = {
         'host': host,
         # todo: get this port dynamically from the cjdroute.conf
         'cjdns_port': CJDNS_DEFAULT_PORT,
@@ -34,19 +62,40 @@ def update_neighbours_config(config, host, port=22):
         'cjdns_ipv6_address': cjdns_ipv6_address,
         'ssh_port': port,
     }
+    if uuid:
+        neighbour_config['uuid'] = uuid
+    config['meshnet']['neighbours'][cjdns_public_key] = neighbour_config
     return config
 
 
-def update_meshnet_config(host, port=22):
+def update_meshnet_config(host, port=22, uuid=None):
     """
     Add a host to the local mutable config
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param str uuid: identifier for a local compute checkout
     :return None:
     """
     log.info("Updating meshnet config with data from host {}".format(host))
     config = load_config(MUTABLE_CONFIG)
     config = update_cjdns_config(config)
     config = update_consul_config(config)
-    config = update_neighbours_config(config, host, port=port)
+    config = update_neighbours_config(
+        config, host, port=port, uuid=uuid
+    )
+    write_config(config, MUTABLE_CONFIG)
+
+
+def ensure_neighbour_removed_from_config(uuid):
+    """
+    Remove a neighbour from the local mutable_config.json by compute checkout uuid
+    :param str uuid: identifier for a local compute checkout
+    :return:
+    """
+    log.debug("Ensuring neighbour with instance checkout uuid {} is "
+              "removed from the mutable_config".format(uuid))
+    config = load_config(MUTABLE_CONFIG)
+    neighbours = {k: v for k, v in config['meshnet']['neighbours'].items()
+                  if v['uuid'] != uuid}
+    config['meshnet']['neighbours'] = neighbours
     write_config(config, MUTABLE_CONFIG)

--- a/raptiformica/shell/compute.py
+++ b/raptiformica/shell/compute.py
@@ -99,7 +99,7 @@ def start_instance(server_type, compute_type, source, boot_command, get_hostname
     :param str boot_command: start instance command
     :param str get_hostname_command: get hostname command
     :param str get_port_command: get port command
-    :return tuple connection_information: host and port
+    :return tuple compute_checkout_information: compute_checkout_uuid, host and port
     """
     log.info("Starting a new {} instance".format(compute_type))
     new_compute_checkout = create_new_compute_checkout(
@@ -112,4 +112,5 @@ def start_instance(server_type, compute_type, source, boot_command, get_hostname
     port = compute_attribute_get(
         new_compute_checkout, get_port_command, "port"
     )
-    return host, port
+    compute_checkout_uuid = new_compute_checkout.split('/')[-1]
+    return compute_checkout_uuid, host, port

--- a/tests/unit/raptiformica/actions/prune/test_fire_clean_up_triggers.py
+++ b/tests/unit/raptiformica/actions/prune/test_fire_clean_up_triggers.py
@@ -7,13 +7,13 @@ from tests.testcase import TestCase
 class TestFireCleanUpTriggers(TestCase):
     def setUp(self):
         self.clean_up_triggers = [
-            ('directory1',
+            ('directory1/some_uuid_1',
              './bin/detect/stale/command1',
              './bin/clean/up/stale/command1'),
-            ('directory2',
+            ('directory2/some_uuid_2',
              './bin/detect/stale/command2',
              './bin/clean/up/stale/command2'),
-            ('directory3',
+            ('directory3/some_uuid_3',
              './bin/detect/stale/command3',
              './bin/clean/up/stale/command3')
         ]
@@ -24,14 +24,17 @@ class TestFireCleanUpTriggers(TestCase):
             'raptiformica.actions.prune.clean_up_stale_instance'
         )
         self.rmtree = self.set_up_patch('raptiformica.actions.prune.rmtree')
+        self.ensure_neighbour_removed_from_config = self.set_up_patch(
+            'raptiformica.actions.prune.ensure_neighbour_removed_from_config'
+        )
 
     def test_fire_clean_up_triggers_checks_if_instances_are_stale(self):
         fire_clean_up_triggers(self.clean_up_triggers)
 
         expected_calls = [
-            call('directory1', './bin/detect/stale/command1'),
-            call('directory2', './bin/detect/stale/command2'),
-            call('directory3', './bin/detect/stale/command3'),
+            call('directory1/some_uuid_1', './bin/detect/stale/command1'),
+            call('directory2/some_uuid_2', './bin/detect/stale/command2'),
+            call('directory3/some_uuid_3', './bin/detect/stale/command3'),
         ]
         self.assertCountEqual(
             self.check_if_instance_is_stale.mock_calls, expected_calls
@@ -44,8 +47,8 @@ class TestFireCleanUpTriggers(TestCase):
         fire_clean_up_triggers(self.clean_up_triggers)
 
         expected_calls = [
-            call('directory1', './bin/clean/up/stale/command1'),
-            call('directory3', './bin/clean/up/stale/command3'),
+            call('directory1/some_uuid_1', './bin/clean/up/stale/command1'),
+            call('directory3/some_uuid_3', './bin/clean/up/stale/command3'),
         ]
         self.assertCountEqual(
             self.clean_up_stale_instance.mock_calls, expected_calls
@@ -58,10 +61,21 @@ class TestFireCleanUpTriggers(TestCase):
         fire_clean_up_triggers(self.clean_up_triggers)
 
         expected_calls = [
-            call('directory1', ignore_errors=True),
-            call('directory2', ignore_errors=True),
+            call('directory1/some_uuid_1', ignore_errors=True),
+            call('directory2/some_uuid_2', ignore_errors=True),
         ]
         self.assertCountEqual(
             self.rmtree.mock_calls,
             expected_calls
+        )
+
+    def test_fire_clean_up_triggers_ensures_cleaned_machine_is_not_in_the_mutable_config_anymore(self):
+        # pretend the secoond and third instance are stale
+        self.check_if_instance_is_stale.side_effect = [False, True, True]
+
+        fire_clean_up_triggers(self.clean_up_triggers)
+
+        expected_calls = map(call, ('some_uuid_2', 'some_uuid_3'))
+        self.assertCountEqual(
+            self.ensure_neighbour_removed_from_config.mock_calls, expected_calls
         )

--- a/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
@@ -27,4 +27,13 @@ class TestAssimilateMachine(TestCase):
     def test_assimilate_machine_updates_meshnet_config(self):
         assimilate_machine('1.2.3.4', port=2222)
 
-        self.update_meshnet_config.assert_called_once_with('1.2.3.4', port=2222)
+        self.update_meshnet_config.assert_called_once_with(
+            '1.2.3.4', port=2222, uuid=None
+        )
+
+    def test_assimilate_machine_updates_meshnet_config_with_optional_uuid(self):
+        assimilate_machine('1.2.3.4', port=2222, uuid='some_uuid_1234')
+
+        self.update_meshnet_config.assert_called_once_with(
+                '1.2.3.4', port=2222, uuid='some_uuid_1234'
+        )

--- a/tests/unit/raptiformica/actions/slave/test_slave_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_slave_machine.py
@@ -48,7 +48,16 @@ class TestSlaveMachine(TestCase):
     def test_slave_machine_assimilates_machine_if_assimilate(self):
         slave_machine('1.2.3.4', port=2222, assimilate=True)
 
-        self.assimilate_machine.assert_called_once_with('1.2.3.4', port=2222)
+        self.assimilate_machine.assert_called_once_with(
+            '1.2.3.4', port=2222, uuid=None
+        )
+
+    def test_slave_machine_assimilates_machines_if_assimilate_with_optional_uuid(self):
+        slave_machine('1.2.3.4', port=2222, assimilate=True, uuid='some_uuid_1234')
+
+        self.assimilate_machine.assert_called_once_with(
+            '1.2.3.4', port=2222, uuid='some_uuid_1234'
+        )
 
     def test_slave_machine_does_not_assimilate_if_assimilate_is_false(self):
         slave_machine('1.2.3.4', port=2222, assimilate=False)

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -9,7 +9,7 @@ class TestSpawnMachine(TestCase):
         self.log = self.set_up_patch('raptiformica.actions.spawn.log')
         self.verify_ssh_agent_running = self.set_up_patch('raptiformica.actions.spawn.verify_ssh_agent_running')
         self.start_compute_type = self.set_up_patch('raptiformica.actions.spawn.start_compute_type')
-        self.start_compute_type.return_value = ('127.0.0.1', 2222)
+        self.start_compute_type.return_value = ('some_uuid_1234', '127.0.0.1', 2222)
         self.slave_machine = self.set_up_patch('raptiformica.actions.spawn.slave_machine')
 
     def test_spawn_machine_logs_spawning_machine_message(self):
@@ -41,7 +41,8 @@ class TestSpawnMachine(TestCase):
             port=2222,
             provision=True,
             assimilate=False,
-            server_type=get_first_server_type()
+            server_type=get_first_server_type(),
+            uuid='some_uuid_1234'
         )
 
     def test_spawn_machine_starts_compute_type_with_provided_server_type_and_compute_type(self):
@@ -61,6 +62,7 @@ class TestSpawnMachine(TestCase):
             port=2222,
             provision=True,
             assimilate=True,
-            server_type='workstation'
+            server_type='workstation',
+            uuid='some_uuid_1234'
         )
 

--- a/tests/unit/raptiformica/settings/meshnet/test_ensure_neighbour_removed_from_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_ensure_neighbour_removed_from_config.py
@@ -1,0 +1,52 @@
+from raptiformica.settings import MUTABLE_CONFIG
+from raptiformica.settings.meshnet import ensure_neighbour_removed_from_config
+from tests.testcase import TestCase
+
+
+class TestEnsureNeighbourRemovedFromConfig(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.settings.meshnet.log')
+        self.load_config = self.set_up_patch('raptiformica.settings.meshnet.load_config')
+        self.write_config = self.set_up_patch('raptiformica.settings.meshnet.write_config')
+        self.config = {
+            'meshnet': {
+                'neighbours': {
+                    'publicKey1': {
+                        'uuid': 'some_uuid_5678'
+                    },
+                    'publicKey2': {
+                        'uuid': 'some_uuid_9999'
+                    }
+                }
+            }
+        }
+        self.load_config.return_value = self.config
+
+    def test_ensure_neighbour_removed_from_config_logs_ensure_neighbour_removed_from_config_debug_message(self):
+        ensure_neighbour_removed_from_config('some_uuid_1234')
+
+        self.assertTrue(self.log.debug.called)
+
+    def test_ensure_neighbours_removed_from_config_loads_mutable_config(self):
+        ensure_neighbour_removed_from_config('some_uuid_1234')
+
+        self.load_config.assert_called_once_with(MUTABLE_CONFIG)
+
+    def test_ensure_neighbour_removed_from_config_does_not_alter_config_when_neighbour_not_in_config(self):
+        ensure_neighbour_removed_from_config('some_uuid_1234')
+
+        self.write_config.assert_called_once_with(self.config, MUTABLE_CONFIG)
+
+    def test_ensure_neighbour_removed_from_config_removed_neighbour_from_config_by_uuid(self):
+        ensure_neighbour_removed_from_config('some_uuid_5678')
+
+        expected_config = {
+            'meshnet': {
+                'neighbours': {
+                    'publicKey2': {
+                        'uuid': 'some_uuid_9999'
+                    }
+                }
+            }
+        }
+        self.write_config.assert_called_once_with(expected_config, MUTABLE_CONFIG)

--- a/tests/unit/raptiformica/settings/meshnet/test_update_meshnet_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_meshnet_config.py
@@ -41,7 +41,15 @@ class TestUpdateMeshnetConfig(TestCase):
 
         self.update_neighbours_config.assert_called_once_with(
             self.update_consul_config.return_value,
-            '1.2.3.4', port=2222
+            '1.2.3.4', port=2222, uuid=None
+        )
+
+    def test_update_meshnet_updates_neighbours_config_with_optional_uuid(self):
+        update_meshnet_config('1.2.3.4', port=2222, uuid='some_uuid_1234')
+
+        self.update_neighbours_config.assert_called_once_with(
+                self.update_consul_config.return_value,
+                '1.2.3.4', port=2222, uuid='some_uuid_1234'
         )
 
     def test_update_meshnet_writes_updated_config_to_disk(self):

--- a/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
@@ -37,3 +37,22 @@ class TestUpdateNeighboursConfig(TestCase):
             }
         }
         self.assertEqual(ret, expected_config)
+
+    def test_update_neighbours_config_returns_updated_config_with_specified_optional_uuid(self):
+        ret = update_neighbours_config(self.config, '1.2.3.4', port=2222, uuid='someuuid1234')
+
+        expected_config = {
+            'meshnet': {
+                'neighbours': {
+                    'a_public_key.k': {
+                        'host': '1.2.3.4',
+                        'cjdns_port': CJDNS_DEFAULT_PORT,
+                        'ssh_port': 2222,
+                        'cjdns_public_key': 'a_public_key.k',
+                        'cjdns_ipv6_address': 'ipv6_address',
+                        'uuid': 'someuuid1234'
+                    }
+                }
+            }
+        }
+        self.assertEqual(ret, expected_config)

--- a/tests/unit/raptiformica/shell/compute/test_start_instance.py
+++ b/tests/unit/raptiformica/shell/compute/test_start_instance.py
@@ -18,6 +18,7 @@ class TestStartInstance(TestCase):
         self.create_new_compute_checkout = self.set_up_patch(
             'raptiformica.shell.compute.create_new_compute_checkout'
         )
+        self.create_new_compute_checkout.return_value = 'var/machines/docker/headless/some_uuid_1234'
         self.boot_instance = self.set_up_patch('raptiformica.shell.compute.boot_instance')
         self.compute_attribute_get = self.set_up_patch('raptiformica.shell.compute.compute_attribute_get')
 
@@ -61,7 +62,8 @@ class TestStartInstance(TestCase):
     def test_start_instance_return_host_and_port(self):
         self.compute_attribute_get.side_effect = ['127.0.0.1', '2222']
 
-        host, port = start_instance(*self.args)
+        uuid, host, port = start_instance(*self.args)
 
+        self.assertEqual(uuid, 'some_uuid_1234')
         self.assertEqual(host, '127.0.0.1')
         self.assertEqual(port, '2222')


### PR DESCRIPTION
when a machine is removed because it was stale, remove matching host(s) (there should only be one ) from the neighbours in the mutable_config
