### PR TITLE
base config can clean up old Vagrants

### DIFF
--- a/.base_config.json
+++ b/.base_config.json
@@ -8,21 +8,27 @@
         "source": "https://github.com/vdloo/vagrantfiles",
         "start_instance_command": "cd headless && vagrant up --provider=virtualbox",
         "hostname_get_command": "cd headless && vagrant ssh-config | grep HostName | awk '{print$NF}'",
-        "port_get_command": "cd headless && vagrant ssh-config | grep Port | awk '{print$NF}'"
+        "port_get_command": "cd headless && vagrant ssh-config | grep Port | awk '{print$NF}'",
+        "detect_stale_instance_command": "cd headless && vagrant status | grep running",
+        "clean_up_instance_command": "cd headless && vagrant destroy -f"
       },
       "workstation":
       {
         "source": "https://github.com/vdloo/vagrantfiles",
         "start_instance_command": "cd gui && vagrant up --provider=virtualbox",
         "hostname_get_command": "cd gui && vagrant ssh-config | grep HostName | awk '{print$NF}'",
-        "port_get_command": "cd gui && vagrant ssh-config | grep Port | awk '{print$NF}'"
+        "port_get_command": "cd gui && vagrant ssh-config | grep Port | awk '{print$NF}'",
+        "detect_stale_instance_command": "cd headless && vagrant status | grep running",
+        "clean_up_instance_command": "cd headless && vagrant destroy -f"
       },
       "htpc":
       {
         "source": "https://github.com/vdloo/vagrantfiles",
         "start_instance_command": "cd gui && vagrant up --provider=virtualbox",
         "hostname_get_command": "cd gui && vagrant ssh-config | grep HostName | awk '{print$NF}'",
-        "port_get_command": "cd gui && vagrant ssh-config | grep Port | awk '{print$NF}'"
+        "port_get_command": "cd gui && vagrant ssh-config | grep Port | awk '{print$NF}'",
+        "detect_stale_instance_command": "cd gui && vagrant status | grep running",
+        "clean_up_instance_command": "cd gui && vagrant destroy -f"
       }
     },
     "docker":

--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -10,7 +10,7 @@ from raptiformica.settings.meshnet import ensure_neighbour_removed_from_config
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type, \
     retrieve_compute_type_config_for_server_type, get_compute_types, get_server_types, \
     verify_server_type_implemented_in_compute_type
-from raptiformica.shell.execute import run_command_print_ready_in_directory_factory, raise_failure_factory
+from raptiformica.shell.execute import run_command_print_ready_in_directory_factory, log_failure_factory
 
 log = getLogger(__name__)
 
@@ -149,10 +149,10 @@ def clean_up_stale_instance(compute_checkout_directory, clean_up_stale_instance_
         compute_checkout_directory, clean_up_stale_instance_command
     )
     exit_code, _, _ = partial_run_command_print_ready(
-        failure_callback=raise_failure_factory(
+        failure_callback=log_failure_factory(
             "Failed to clean up stale instance"
         ),
-        buffered=False
+        buffered=True
     )
 
 

--- a/tests/unit/raptiformica/actions/prune/test_clean_up_stale_instance.py
+++ b/tests/unit/raptiformica/actions/prune/test_clean_up_stale_instance.py
@@ -34,14 +34,12 @@ class TestCleanUpStaleInstance(TestCase):
                             '{}'.format(self.clean_up_stale_instance_command)]
         self.execute_process.assert_called_once_with(
                 expected_command,
-                buffered=False,
+                buffered=True,
                 shell=False
         )
 
-    def test_clean_up_stale_instance_raises_error_when_command_failed(self):
+    def test_clean_up_stale_instance_does_not_raise_error_when_command_failed(self):
         self.process_output = (1, '', 'standard error output')
-
         self.execute_process.return_value = self.process_output
 
-        with self.assertRaises(RuntimeError):
-            clean_up_stale_instance(*self.args)
+        clean_up_stale_instance(*self.args)


### PR DESCRIPTION
Find inactive machines like:

```
+        "detect_stale_instance_command": "cd headless && vagrant status | grep running",
```

Clean up inactive machines like:

```
+        "clean_up_instance_command": "cd headless && vagrant destroy -f"
```
