### PR TITLE
Add main entrypoint script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all clean
+
+NAME := raptiformica
+VERSION := 0.1
+MAINTAINER := Rick van de Loo <rickvandeloo@gmail.com>
+DESCRIPTION := Decentralized server orchestration
+
+test:
+	./runtests.sh -1
+install:
+	sudo mkdir -p /usr/share/raptiformica
+	sudo cp -R . /usr/share/raptiformica
+	sudo ln -sf /usr/share/raptiformica/bin/raptiformica /usr/bin/raptiformica
+	sudo chmod u+x /usr/bin/raptiformica
+uninstall:
+	sudo rm -rf /usr/share/raptiformica
+	sudo rm -f /usr/bin/raptiformica
+clean:
+	git clean -xfd
+

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ Usage
 Get the code
 ```
 git clone https://github.com/vdloo/raptiformica; cd raptiformica
+
+# System wide installation (optional)
+make install
 ```
+
 
 Make sure you have an SSH agent running
 ```
@@ -91,19 +95,17 @@ eval $(ssh-agent -s); ssh-add
 
 Booting a virtualized cluster:
 ```
-export PYTHONPATH=.  
-
-rm -f mutable_config.json  # clean up configs from a previous cluster if there is one
+sudo rm -f mutable_config.json  # clean up configs from a previous cluster if there is one
 ```
 
 ```
 # Boot a Vagrant (will spawn two dockers in the VM to ensure 3 machines)
-./bin/raptiformica_spawn.py --compute-type vagrant --verbose
+sudo -E raptiformica spawn --compute-type vagrant --verbose
 ```
 
 Log in to one of the machines to access the network
 ```
-./bin/raptiformica_members.py
+sudo -E raptiformica members
 Node           Address               Status  Type    Build  Protocol  DC
 fc16:...:fd12  [fc16:...:fd12]:8301  alive   server  0.6.4  2         raptiformica
 fc16:...:fa0e  [fc16:...:fa0e]:8301  alive   server  0.6.4  2         raptiformica

--- a/bin/raptiformica
+++ b/bin/raptiformica
@@ -1,0 +1,64 @@
+#!/bin/bash
+export PYTHONPATH=../
+
+SPAWN_ENTRYPOINT="raptiformica_spawn.py"
+PRUNE_ENTRYPOINT="raptiformica_prune.py"
+MEMBERS_ENTRYPOINT="raptiformica_members.py"
+MESH_ENTRYPOINT="raptiformica_mesh.py"
+SLAVE_ENTRYPOINT="raptiformica_slave.py"
+
+function print_help {
+    cat <<'END'
+Usage: raptiformica [CMD..] [OPTIONS] [-h]
+
+  spawn                      Spawn a machine to slave and 
+                             assimilate into the network
+
+  slave                      Provision and join a machine 
+                             into the network
+
+  mesh                       Deploy a mesh configuration 
+                             based on the config file on 
+                             this machine and attempt to 
+                             join the distributed network
+
+  prune                      Clean up inactive instances
+
+  members                    Show the members of the 
+                             distributed network.
+END
+}
+
+case $1 in 
+    spawn)
+    RAPTIFORMICA_CMD=$SPAWN_ENTRYPOINT
+    shift 
+    ;;
+    prune)
+    RAPTIFORMICA_CMD=$PRUNE_ENTRYPOINT
+    shift
+    ;;
+    members)
+    RAPTIFORMICA_CMD=$MEMBERS_ENTRYPOINT
+    shift
+    ;;
+    mesh)
+    RAPTIFORMICA_CMD=$MESH_ENTRYPOINT
+    shift
+    ;;
+    slave)
+    RAPTIFORMICA_CMD=$SLAVE_ENTRYPOINT
+    shift
+    ;;
+    *)
+    print_help;
+    exit 1
+    ;;
+esac
+
+ENTRYPOINT_SCRIPT_PATH=$(readlink -f "$0")
+RAPTIFORMICA_BIN_DIRECTORY=$(dirname "$ENTRYPOINT_SCRIPT_PATH")
+RAPTIFORMICA_DIRECTORY=$(dirname "$RAPTIFORMICA_BIN_DIRECTORY")
+
+export PYTHONPATH=$RAPTIFORMICA_DIRECTORY
+$RAPTIFORMICA_BIN_DIRECTORY/$RAPTIFORMICA_CMD $@

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -30,6 +30,7 @@ def parse_slave_arguments():
     :return dict args: parsed arguments
     """
     parser = ArgumentParser(
+        prog="raptiformica slave",
         description='Provision and join a machine into the network'
     )
     parser.add_argument('host', type=str,
@@ -67,6 +68,7 @@ def parse_spawn_arguments():
     :return dict args: parsed arguments
     """
     parser = ArgumentParser(
+        prog="raptiformica spawn",
         description='Spawn a machine to slave and assimilate into the network'
     )
     parser.add_argument('--no-provision', action='store_true', default=False,
@@ -103,6 +105,7 @@ def parse_mesh_arguments():
     :return dict args: parsed arguments
     """
     parser = ArgumentParser(
+        prog="raptiformica mesh",
         description='Deploy a mesh configuration based on the {} config '
                     'file on this machine and attempt to join '
                     'the distributed network'.format(MUTABLE_CONFIG)
@@ -125,6 +128,7 @@ def parse_members_arguments():
     :return dict args: parsed arguments
     """
     parser = ArgumentParser(
+        prog="raptiformica members",
         description="Show the members of the distributed network."
     )
     return parse_arguments(parser)
@@ -146,6 +150,7 @@ def parse_prune_arguments():
     :return dict args: parsed arguments
     """
     parser = ArgumentParser(
+        prog="raptiformica prune",
         description="Clean up inactive instances"
     )
     return parse_arguments(parser)

--- a/tests/unit/raptiformica/cli/test_parse_members_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_members_arguments.py
@@ -11,6 +11,7 @@ class TestParseMembersArguments(TestCase):
         parse_members_arguments()
 
         self.argument_parser.assert_called_once_with(
+            prog='raptiformica members',
             description="Show the members of the distributed network."
         )
 

--- a/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
@@ -12,6 +12,7 @@ class TestParseMeshArguments(TestCase):
         parse_mesh_arguments()
 
         self.argument_parser.assert_called_once_with(
+            prog='raptiformica mesh',
             description='Deploy a mesh configuration based on the {} config '
                         'file on this machine and attempt to join '
                         'the distributed network'.format(MUTABLE_CONFIG)

--- a/tests/unit/raptiformica/cli/test_parse_prune_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_prune_arguments.py
@@ -11,7 +11,8 @@ class TestParsePruneArguments(TestCase):
         parse_prune_arguments()
 
         self.argument_parser.assert_called_once_with(
-                description="Clean up inactive instances"
+            prog='raptiformica prune',
+            description="Clean up inactive instances"
         )
 
     def test_parse_prune_arguments_adds_arguments(self):

--- a/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
@@ -14,6 +14,7 @@ class TestParseSlaveArguments(TestCase):
         parse_slave_arguments()
 
         self.argument_parser.assert_called_once_with(
+            prog='raptiformica slave',
             description='Provision and join a machine into the network'
         )
 

--- a/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
@@ -15,6 +15,7 @@ class TestParseSpawnArguments(TestCase):
         parse_spawn_arguments()
 
         self.argument_parser.assert_called_once_with(
+            prog='raptiformica spawn',
             description='Spawn a machine to slave and assimilate into the network'
         )
 


### PR DESCRIPTION
```
$ sudo make install
sudo mkdir -p /usr/share/raptiformica
sudo cp -R . /usr/share/raptiformica
sudo ln -sf /usr/share/raptiformica/bin/raptiformica
/usr/bin/raptiformica
sudo chmod u+x /usr/bin/raptiformica

$ sudo raptiformica --help
Usage: raptiformica [CMD..] [OPTIONS] [-h]

  spawn                      Spawn a machine to slave and
                             assimilate into the network

  slave                      Provision and join a machine
                             into the network

  mesh                       Deploy a mesh configuration
                             based on the config file on
                             this machine and attempt to
                             join the distributed network

  prune                      Clean up inactive instances

  members                    Show the members of the
                             distributed network.

$ sudo raptiformica spawn --help
usage: raptiformica spawn [-h] [--no-provision] [--no-assimilate]
                          [--server-type {headless,htpc,workstation}]
                          [--compute-type {docker,vagrant}] [--verbose]

Spawn a machine to slave and assimilate into the network

optional arguments:
  -h, --help            show this help message and exit
  --no-provision        Do not run the provisioning scripts for the specified
                        server type
  --no-assimilate       Do not join or set up the distributed network.
  --server-type {headless,htpc,workstation}
                        Specify a server type. Default is headless
  --compute-type {docker,vagrant}
                        Specify a compute type. Default is docker
  --verbose, -v
```