### PR TITLE
re-enable removing neighbours from config on purge

### DIFF
--- a/raptiformica/distributed/kv.py
+++ b/raptiformica/distributed/kv.py
@@ -46,3 +46,23 @@ def get_kv(path, recurse=False):
         r['Key']: b64decode(r['Value']).decode('utf-8') for r in result
     }
     return mapping
+
+
+def delete_kv(path, recurse=False):
+    """
+    Delete a key from the distributed key value mapping
+    :param str path: path to the key to remove
+    :param bool recurse: recurse the path and delete all entries
+    :return:
+    """
+    req = request.Request(
+        url=join(path, '?recurse') if recurse else path,
+        method='DELETE'
+    )
+    with request.urlopen(req) as f:
+        log.debug("DELETEd key {}{}: {} {}".format(
+            path,
+            ' recursively' if recurse else '',
+            f.status,
+            f.reason
+        ))

--- a/tests/unit/raptiformica/actions/mesh/test_get_cjdns_password.py
+++ b/tests/unit/raptiformica/actions/mesh/test_get_cjdns_password.py
@@ -15,7 +15,7 @@ class TestGetCJDNSPassword(TestCase):
             "raptiformica/meshnet/neighbours/a_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf2",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_ipv6_address": "some_other_ipv6_address",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_port": 4863,
-            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_public_key": "a_different_ubkey.k",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_public_key": "a_different_pubkey.k",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/host": "127.0.0.1",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/ssh_port": "2201",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",

--- a/tests/unit/raptiformica/actions/prune/test_ensure_neighbour_removed_from_config.py
+++ b/tests/unit/raptiformica/actions/prune/test_ensure_neighbour_removed_from_config.py
@@ -1,0 +1,73 @@
+from mock import call
+
+from raptiformica.actions.prune import ensure_neighbour_removed_from_config
+from tests.testcase import TestCase
+
+
+class TestEnsureNeighbourRemovedFromConfig(TestCase):
+    def setUp(self):
+        self.get_config = self.set_up_patch(
+            'raptiformica.actions.prune.get_config'
+        )
+        self.mapping = {
+            "raptiformica/meshnet/cjdns/password": "a_secret",
+            "raptiformica/meshnet/consul/password": "a_different_secret",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_ipv6_address": "some_ipv6_address",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_port": 4863,
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_public_key": "a_pubkey.k",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/host": "127.0.0.1",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/ssh_port": "2200",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf2",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_ipv6_address": "some_other_ipv6_address",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_port": 4863,
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_public_key": "a_different_pubkey.k",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/host": "127.0.0.1",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/ssh_port": "2201",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",
+        }
+        self.get_config.return_value = self.mapping
+        self.try_delete_config = self.set_up_patch(
+            'raptiformica.actions.prune.try_delete_config'
+        )
+
+    def test_ensure_neighbour_removed_from_config_gets_mapping(self):
+        ensure_neighbour_removed_from_config("some_uuid")
+
+        self.get_config.assert_called_once_with()
+
+    def test_ensure_neighbour_removed_from_config_removes_neighbour_by_uuid_from_config(self):
+        ensure_neighbour_removed_from_config("eb442c6170694b12b277c9e88d714cf2")
+
+        self.try_delete_config.assert_called_once_with(
+            'raptiformica/meshnet/neighbours/a_pubkey.k/',
+            recurse=True
+        )
+
+    def test_ensure_neighbour_removed_from_config_removes_all_entries_with_matching_uuid(self):
+        # pretend the uuid of the other neighbour is the same as the first,
+        # we should then also then remove that entry
+        self.mapping[
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid"
+        ] = "eb442c6170694b12b277c9e88d714cf2"
+        self.get_config.return_value = self.mapping
+
+        ensure_neighbour_removed_from_config("eb442c6170694b12b277c9e88d714cf2")
+
+        expected_calls = (
+            call(
+                'raptiformica/meshnet/neighbours/a_pubkey.k/',
+                recurse=True
+            ),
+            call(
+                'raptiformica/meshnet/neighbours/a_different_pubkey.k/',
+                recurse=True
+            )
+        )
+        self.assertCountEqual(
+            self.try_delete_config.mock_calls, expected_calls
+        )
+
+    def test_ensure_neighbour_removed_from_config_does_not_remove_any_entries_if_no_uuid_match(self):
+        ensure_neighbour_removed_from_config("not_a_matching_uuid")
+
+        self.assertFalse(self.try_delete_config.called)

--- a/tests/unit/raptiformica/actions/prune/test_fire_clean_up_triggers.py
+++ b/tests/unit/raptiformica/actions/prune/test_fire_clean_up_triggers.py
@@ -24,6 +24,9 @@ class TestFireCleanUpTriggers(TestCase):
             'raptiformica.actions.prune.clean_up_stale_instance'
         )
         self.rmtree = self.set_up_patch('raptiformica.actions.prune.rmtree')
+        self. ensure_neighbour_removed_from_config = self.set_up_patch(
+            'raptiformica.actions.prune.ensure_neighbour_removed_from_config'
+        )
 
     def test_fire_clean_up_triggers_checks_if_instances_are_stale(self):
         fire_clean_up_triggers(self.clean_up_triggers)
@@ -66,13 +69,13 @@ class TestFireCleanUpTriggers(TestCase):
             expected_calls
         )
 
-    # def test_fire_clean_up_triggers_ensures_cleaned_machine_is_not_in_the_mutable_config_anymore(self):
-    #     # pretend the secoond and third instance are stale
-    #     self.check_if_instance_is_stale.side_effect = [False, True, True]
-    #
-    #     fire_clean_up_triggers(self.clean_up_triggers)
-    #
-    #     expected_calls = map(call, ('some_uuid_2', 'some_uuid_3'))
-    #     self.assertCountEqual(
-    #         self.ensure_neighbour_removed_from_config.mock_calls, expected_calls
-    #     )
+    def test_fire_clean_up_triggers_ensures_cleaned_machine_is_not_in_the_mutable_config_anymore(self):
+        # pretend the secoond and third instance are stale
+        self.check_if_instance_is_stale.side_effect = [False, True, True]
+
+        fire_clean_up_triggers(self.clean_up_triggers)
+
+        expected_calls = map(call, ('some_uuid_2', 'some_uuid_3'))
+        self.assertCountEqual(
+            self.ensure_neighbour_removed_from_config.mock_calls, expected_calls
+        )

--- a/tests/unit/raptiformica/distributed/kv/test_delete_kv.py
+++ b/tests/unit/raptiformica/distributed/kv/test_delete_kv.py
@@ -1,0 +1,41 @@
+from mock import Mock
+
+from raptiformica.distributed.kv import delete_kv
+from tests.testcase import TestCase
+
+
+class TestDeleteKV(TestCase):
+    def setUp(self):
+        self.request = self.set_up_patch('raptiformica.distributed.kv.request')
+        self.request.urlopen.return_value.__exit__ = lambda a, b, c, d: None
+        self.request.urlopen.return_value.__enter__ = lambda x: Mock()
+        self.log = self.set_up_patch('raptiformica.distributed.kv.log')
+
+    def test_delete_kv_instantiates_request_object(self):
+        delete_kv('some/path')
+
+        self.request.Request.assert_called_once_with(
+            url='some/path',
+            method='DELETE'
+        )
+
+    def test_delete_kv_deletes_all_nested_values_if_specified(self):
+        delete_kv('some/path', recurse=True)
+
+        self.request.Request.assert_called_once_with(
+            url='some/path/?recurse',
+            method='DELETE'
+        )
+
+    def test_delete_kv_does_request(self):
+        delete_kv('some/path')
+
+        self.request.urlopen.assert_called_once_with(
+            self.request.Request.return_value
+        )
+
+    def test_delete_kv_logs_debug_message(self):
+        delete_kv('some/path')
+
+        self.assertTrue(self.log.debug)
+

--- a/tests/unit/raptiformica/distributed/kv/test_get_kv.py
+++ b/tests/unit/raptiformica/distributed/kv/test_get_kv.py
@@ -17,7 +17,7 @@ class TestGetKV(TestCase):
             )
         )
 
-    def test_kv_instantiates_request_object(self):
+    def test_get_kv_instantiates_request_object(self):
         get_kv('some/path')
 
         self.request.Request.assert_called_once_with(
@@ -25,22 +25,22 @@ class TestGetKV(TestCase):
             method='GET'
         )
 
-    def test_kv_gets_all_nested_values_if_specified(self):
+    def test_get_kv_gets_all_nested_values_if_specified(self):
         get_kv('some/path', recurse=True)
 
         self.request.Request.assert_called_once_with(
-                url='some/path/?recurse',
-                method='GET'
+            url='some/path/?recurse',
+            method='GET'
         )
 
-    def test_kv_does_request(self):
+    def test_get_kv_does_request(self):
         get_kv('some/path', recurse=True)
 
         self.request.urlopen.assert_called_once_with(
-                self.request.Request.return_value
+            self.request.Request.return_value
         )
 
-    def test_kv_returns_mapping(self):
+    def test_get_kv_returns_mapping(self):
         ret = get_kv('some/path', recurse=True)
 
         expected_mapping = {

--- a/tests/unit/raptiformica/settings/load/test_try_delete_config.py
+++ b/tests/unit/raptiformica/settings/load/test_try_delete_config.py
@@ -1,0 +1,89 @@
+from urllib.error import URLError
+
+from raptiformica.settings.load import try_delete_config
+from tests.testcase import TestCase
+
+
+class TestTryDeleteConfig(TestCase):
+    def setUp(self):
+        self.delete_kv = self.set_up_patch(
+            'raptiformica.settings.load.delete_kv'
+        )
+        self.mapping = {
+            "raptiformica/meshnet/cjdns/password": "a_secret",
+            "raptiformica/meshnet/consul/password": "a_different_secret",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_ipv6_address": "some_ipv6_address",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_port": 4863,
+            "raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_public_key": "a_pubkey.k",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/host": "127.0.0.1",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/ssh_port": "2200",
+            "raptiformica/meshnet/neighbours/a_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf2",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_ipv6_address": "some_other_ipv6_address",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_port": 4863,
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/cjdns_public_key": "a_different_pubkey.k",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/host": "127.0.0.1",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/ssh_port": "2201",
+            "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",
+        }
+        self.get_config = self.set_up_patch(
+            'raptiformica.settings.load.get_config',
+            return_value=self.mapping
+        )
+        self.get_config.return_value = self.mapping
+        self.cache_config = self.set_up_patch(
+            'raptiformica.settings.load.cache_config'
+        )
+
+    def test_try_delete_config_deletes_key_pair_from_distributed_kv_store(self):
+        try_delete_config('some/key')
+
+        self.delete_kv.assert_called_once_with(
+            'http://localhost:8500/v1/kv/some/key',
+            recurse=False
+        )
+
+    def test_try_delete_config_deletes_key_pair_from_distributed_kv_store_recursively_if_specified(self):
+        try_delete_config('some/key', recurse=True)
+
+        self.delete_kv.assert_called_once_with(
+            'http://localhost:8500/v1/kv/some/key',
+            recurse=True
+        )
+
+    def test_try_delete_config_gets_config_if_can_not_connect_to_shared_key_value_store(self):
+        self.delete_kv.side_effect = URLError('reason')
+
+        try_delete_config('key')
+
+        self.get_config.assert_called_once_with()
+
+    def test_try_delete_config_caches_config_without_key_if_can_not_connect_to_shared_key_value_store(self):
+        self.delete_kv.side_effect = URLError('reason')
+
+        try_delete_config('raptiformica/meshnet/neighbours/a_pubkey.k/uuid')
+
+        del self.mapping[
+            'raptiformica/meshnet/neighbours/a_pubkey.k/uuid'
+        ]
+        self.cache_config.assert_called_once_with(self.mapping)
+
+    def test_try_delete_config_caches_config_without_entire_key_tree_if_no_shared_kv_and_recurse_is_specified(self):
+        self.delete_kv.side_effect = URLError('reason')
+
+        try_delete_config(
+            'raptiformica/meshnet/neighbours/a_pubkey.k/', recurse=True
+        )
+
+        del self.mapping['raptiformica/meshnet/neighbours/a_pubkey.k/uuid']
+        del self.mapping['raptiformica/meshnet/neighbours/a_pubkey.k/host']
+        del self.mapping['raptiformica/meshnet/neighbours/a_pubkey.k/ssh_port']
+        del self.mapping[
+            'raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_port'
+        ]
+        del self.mapping[
+            'raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_ipv6_address'
+        ]
+        del self.mapping[
+            'raptiformica/meshnet/neighbours/a_pubkey.k/cjdns_public_key'
+        ]
+        self.cache_config.assert_called_once_with(self.mapping)


### PR DESCRIPTION
cluster change events trigger a check for dead instances bound
to the local machine and then removes those instances and the
 entries in the distributed key value store linked to the uuid
found in the deceased machine's compute checkout directory