### PR TITLE
count neighbours also counts double items

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -142,6 +142,17 @@ def configure_consul_conf():
     write_json(consul_config, CONSUL_CONF_PATH)
 
 
+def count_neighbours():
+    """
+    Count the amount of peers in the distributed network
+    :return:
+    """
+    mapping = get_config()
+    cjdroute_config = load_json(CJDROUTE_CONF_PATH)
+    local_public_key = cjdroute_config['publicKey']
+    return len([pk for pk in list_neighbours(mapping) if pk != local_public_key])
+
+
 def enough_neighbours():
     """
     Check if there are enough neighbours to bootstrap or
@@ -150,13 +161,13 @@ def enough_neighbours():
     :return:
     """
     log.info("Checking if there are enough neighbours to mesh with")
-    mapping = get_config()
-    neighbours = parse_cjdns_neighbours(mapping)
-    enough = len(neighbours) >= 2
+    amount = count_neighbours()
+
+    enough = amount >= 2
     if not enough:
         log.warning("Not enough machines to bootstrap meshnet. "
-                    "Need {} more.".format(2 - len(neighbours)))
-    elif len(neighbours) == 2:
+                    "Need {} more.".format(2 - amount))
+    elif amount == 2:
         log.info("New meshnet will be established")
     return enough
 

--- a/tests/unit/raptiformica/actions/mesh/test_count_neighbours.py
+++ b/tests/unit/raptiformica/actions/mesh/test_count_neighbours.py
@@ -1,0 +1,45 @@
+from raptiformica.actions.mesh import count_neighbours, CJDROUTE_CONF_PATH
+from tests.testcase import TestCase
+
+
+class TestCountNeighbours(TestCase):
+    def setUp(self):
+        self.get_config = self.set_up_patch(
+            'raptiformica.actions.mesh.get_config'
+        )
+        self.load_json = self.set_up_patch(
+            'raptiformica.actions.mesh.load_json'
+        )
+        self.load_json.return_value = {'publicKey': 'key3'}
+        self.list_neighbours = self.set_up_patch(
+            'raptiformica.actions.mesh.list_neighbours'
+        )
+        self.list_neighbours.return_value = [
+            'key1',
+            'key2',
+            'key3',
+            'key4',
+            'key5'
+        ]
+
+    def test_count_neighbours_gets_config(self):
+        count_neighbours()
+
+        self.get_config.assert_called_once_with()
+
+    def test_count_neighbours_loads_cjdroute_config(self):
+        count_neighbours()
+
+        self.load_json.assert_called_once_with(CJDROUTE_CONF_PATH)
+
+    def test_count_neighbours_lists_all_cjdns_public_keys_from_mapping(self):
+        count_neighbours()
+
+        self.list_neighbours.assert_called_once_with(
+            self.get_config.return_value
+        )
+
+    def test_count_neighbours_counts_public_keys_except_self(self):
+        ret = count_neighbours()
+
+        self.assertEqual(ret, 4)

--- a/tests/unit/raptiformica/actions/mesh/test_enough_neighbours.py
+++ b/tests/unit/raptiformica/actions/mesh/test_enough_neighbours.py
@@ -5,9 +5,8 @@ from tests.testcase import TestCase
 class TestEnoughNeighbours(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
-        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config')
-        self.parse_cjdns_neighbours = self.set_up_patch('raptiformica.actions.mesh.parse_cjdns_neighbours')
-        self.parse_cjdns_neighbours.return_value = []
+        self.count_neighbours = self.set_up_patch('raptiformica.actions.mesh.count_neighbours')
+        self.count_neighbours.return_value = 0
 
     def test_enough_neighbours_logs_checking_enough_neighbours_message(self):
         enough_neighbours()
@@ -17,7 +16,7 @@ class TestEnoughNeighbours(TestCase):
     def test_enough_neighbours_calls_parse_enough_neighbours_with_retrieved_mapping(self):
         enough_neighbours()
 
-        self.parse_cjdns_neighbours.assert_called_once_with(self.get_config.return_value)
+        self.count_neighbours.assert_called_once_with()
 
     def test_enough_neighbours_warns_not_enough_neighbours_when_no_neighbours(self):
         enough_neighbours()
@@ -25,28 +24,28 @@ class TestEnoughNeighbours(TestCase):
         self.assertTrue(self.log.warning.called)
 
     def test_enough_neighbours_warns_not_enough_neighbours_when_one_neighbour(self):
-        self.parse_cjdns_neighbours.return_value = [{}]
+        self.count_neighbours.return_value = 1
 
         enough_neighbours()
 
         self.assertTrue(self.log.warning.called)
 
     def test_enough_neighbours_does_not_warn_not_enough_neighbours_when_two_neighbours(self):
-        self.parse_cjdns_neighbours.return_value = [{}, {}]
+        self.count_neighbours.return_value = 2
 
         enough_neighbours()
 
         self.assertFalse(self.log.warning.called)
 
     def test_enough_neighbours_returns_true_if_enough_neighbours(self):
-        self.parse_cjdns_neighbours.return_value = [{}, {}]
+        self.count_neighbours.return_value = 2
 
         ret = enough_neighbours()
 
         self.assertTrue(ret)
 
     def test_enough_neighbours_returns_false_if_not_enough_neighbours(self):
-        self.parse_cjdns_neighbours.return_value = []
+        self.count_neighbours.return_value = 0
 
         ret = enough_neighbours()
 


### PR DESCRIPTION
it can be that a machine in a different subnet or zone has the same
address as another. There is no distinction between these in the
meshnet config (it is by address, not pubkey) because it does not
matter in that context, but it does matter when deciding when to try to
bootstap the distributed network. This commmit adds a function that
counts the neighbours (not unique) and excludes the public key that
belongs to the caller.