### PR TITLE
ensure ipv6 routes

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_ensure_ipv6_routing.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_ipv6_routing.py
@@ -1,0 +1,27 @@
+from mock import call
+from tests.testcase import TestCase
+
+from raptiformica.actions.mesh import ensure_ipv6_routing
+
+
+class TestEnsureIPv6Routing(TestCase):
+    def setUp(self):
+        self.run_command_print_ready = self.set_up_patch(
+            'raptiformica.actions.mesh.run_command_print_ready'
+        )
+
+    def test_ensure_ipv6_routing_runs_ip_add_command_for_all_routing_rules(self):
+        ensure_ipv6_routing()
+
+        expected_calls = (
+            call('ip -6 route add fe80::/64 dev eth0  '
+                 'proto kernel  metric 256  pref medium',
+                 shell=True),
+            call('ip -6 route add fc00::/8 dev tun0  '
+                 'proto kernel  metric 256  mtu 1304 pref medium',
+                 shell=True),
+        )
+        self.assertCountEqual(
+                self.run_command_print_ready.mock_calls,
+                expected_calls
+        )

--- a/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
@@ -6,7 +6,9 @@ class TestStartMeshingServices(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
         self.start_detached_cjdroute = self.set_up_patch('raptiformica.actions.mesh.start_detached_cjdroute')
+        self.ensure_ipv6_routing = self.set_up_patch('raptiformica.actions.mesh.ensure_ipv6_routing')
         self.start_detached_consul_agent = self.set_up_patch('raptiformica.actions.mesh.start_detached_consul_agent')
+        self.sleep = self.set_up_patch('raptiformica.actions.mesh.sleep')
 
     def test_start_meshing_services_logs_meshing_services_message(self):
         start_meshing_services()
@@ -17,6 +19,16 @@ class TestStartMeshingServices(TestCase):
         start_meshing_services()
 
         self.start_detached_cjdroute.assert_called_once_with()
+
+    def test_start_meshing_services_waits_a_bit_for_cjdroute_to_initialize(self):
+        start_meshing_services()
+
+        self.sleep.assert_called_once_with(10)
+
+    def test_start_meshing_services_ensure_ipv6_routing(self):
+        start_meshing_services()
+
+        self.ensure_ipv6_routing.assert_called_once_with()
 
     def test_start_meshing_services_starts_detached_consul_agent(self):
         start_meshing_services()


### PR DESCRIPTION
the necessary routes do not always exists after cjdroute has started.
This commit runs 'ip -6 add' for the required routes after cjdoute has
started (so the tun0 device exists)