### PR TITLE
implement 'raptiformica ssh'

### DIFF
--- a/bin/raptiformica
+++ b/bin/raptiformica
@@ -8,6 +8,7 @@ MESH_ENTRYPOINT="raptiformica_mesh.py"
 SLAVE_ENTRYPOINT="raptiformica_slave.py"
 HOOK_ENTRYPOINT="raptiformica_hook.py"
 MODPROBE_ENTRYPOINT="raptiformica_modprobe.py"
+SSH_ENTRYPOINT="raptiformica_ssh.py"
 
 function print_help {
     cat <<'END'
@@ -34,6 +35,8 @@ Usage: raptiformica [CMD..] [OPTIONS] [-h]
 
   members                    Show the members of the 
                              distributed network.
+
+  ssh                        SSH into one of the machines
 END
 }
 
@@ -44,6 +47,10 @@ case $1 in
     ;;
     prune)
     RAPTIFORMICA_CMD=$PRUNE_ENTRYPOINT
+    shift
+    ;;
+    ssh)
+    RAPTIFORMICA_CMD=$SSH_ENTRYPOINT
     shift
     ;;
     members)

--- a/bin/raptiformica_ssh.py
+++ b/bin/raptiformica_ssh.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+from raptiformica.cli import ssh
+
+if __name__ == '__main__':
+    ssh()
+else:
+    raise RuntimeError("This script is an entry point and can not be imported")

--- a/raptiformica/actions/ssh_connect.py
+++ b/raptiformica/actions/ssh_connect.py
@@ -1,0 +1,27 @@
+from logging import getLogger
+
+from os import system
+
+from raptiformica.distributed.discovery import host_and_port_pairs_from_mutable_config
+from raptiformica.shell.ssh import get_ssh_connection
+
+log = getLogger(__name__)
+
+
+def ssh_connect(info_only=False):
+    """
+    Connect to one of the machines over SSH
+    :param bool info_only: Only print connection info, don't get a shell
+    :return None:
+    """
+    host_and_port_pairs = host_and_port_pairs_from_mutable_config()
+    host, port = get_ssh_connection(host_and_port_pairs)
+    if host and port:
+        ssh_command = "ssh root@{} -p {} " \
+                      "-oStrictHostKeyChecking=no " \
+                      "-oUserKnownHostsFile=/dev/null " \
+                      "-oPasswordAuthentication=no".format(host, port)
+        if info_only:
+            print(ssh_command)
+        else:
+            system(ssh_command)

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -7,6 +7,7 @@ from raptiformica.actions.modules import load_module, unload_module
 from raptiformica.actions.prune import prune_local_machines
 from raptiformica.actions.slave import slave_machine
 from raptiformica.actions.spawn import spawn_machine
+from raptiformica.actions.ssh_connect import ssh_connect
 from raptiformica.settings import MUTABLE_CONFIG
 from raptiformica.settings.types import get_server_types, get_first_server_type, get_first_compute_type, \
     get_compute_types
@@ -151,6 +152,31 @@ def hook():
     # that trigger this hook can be used to perform actions based on the
     # content of the event.
     trigger_handlers(hook_name=args.name)
+
+
+def parse_ssh_arguments():
+    """
+    Parse the commandline options for connecting to one of the machines over SSH
+    :return obj args: parsed arguments
+    """
+    parser = ArgumentParser(
+        prog="raptiformica ssh",
+        description="SSH into one of the machines"
+    )
+    parser.add_argument(
+        '--info-only', action='store_true',
+        help="Don't get a shell. Only print the command to connect."
+    )
+    return parse_arguments(parser)
+
+
+def ssh():
+    """
+    Connect to one of the machines over ssh
+    :return None:
+    """
+    args = parse_ssh_arguments()
+    ssh_connect(info_only=args.info_only)
 
 
 def parse_members_arguments():

--- a/raptiformica/distributed/exec.py
+++ b/raptiformica/distributed/exec.py
@@ -16,7 +16,7 @@ def try_machine_command(host_and_port_pairs, command_as_list,
     :param list[str, ..] command_as_list: list of strings which build up the command that will be executed
     :param str attempt_message: The message to log to debug before every attempt. Formats 'host' and 'port'
     :param str all_failed_message: The message to log as warning when we ran out of hosts to try
-    :return str standard_out_output | None: command result or None
+    :return tuple(str standard_out_output, str host, str port) | tuple(None, None, None)
     """
     for host, port in host_and_port_pairs:
         log.debug(attempt_message.format(host, port))
@@ -24,5 +24,6 @@ def try_machine_command(host_and_port_pairs, command_as_list,
             command_as_list, host, port=port
         )
         if exit_code == 0:
-            return standard_out_output.strip()
+            return standard_out_output.strip(), host, port
     log.warning(all_failed_message)
+    return None, None, None

--- a/raptiformica/distributed/members.py
+++ b/raptiformica/distributed/members.py
@@ -16,9 +16,10 @@ def try_get_members_list(host_and_port_pairs):
     all_failed_message = "Could not list members in the distributed network. " \
                          "Maybe no meshnet has been established yet. " \
                          "Do you have at least three machines running?"
-    return try_machine_command(
+    output, _, _ = try_machine_command(
         host_and_port_pairs,
         list_members_command,
         attempt_message=attempt_message,
         all_failed_message=all_failed_message
     )
+    return output

--- a/raptiformica/shell/execute.py
+++ b/raptiformica/shell/execute.py
@@ -69,7 +69,7 @@ def execute_process(command, buffered=True, shell=False):
         command, stdout=PIPE,
         universal_newlines=buffered,
         stderr=PIPE, shell=shell,
-        bufsize=-1 if buffered else 1
+        bufsize=-1 if buffered else 0
     )
     if not buffered:
         for line in iter(process.stdout.readline, b''):
@@ -225,6 +225,7 @@ def run_command_remotely(command_as_list, host, port=22,
     ssh_command_as_list = ['/usr/bin/env', 'ssh',
                            '-o', 'StrictHostKeyChecking=no',
                            '-o', 'UserKnownHostsFile=/dev/null',
+                           '-o', 'PasswordAuthentication=no',
                            'root@{}'.format(host), '-p', str(port)]
     return run_command(
         ssh_command_as_list + command_as_list,

--- a/raptiformica/shell/ssh.py
+++ b/raptiformica/shell/ssh.py
@@ -1,11 +1,16 @@
 from logging import getLogger
 
+from raptiformica.distributed.exec import try_machine_command
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory
 
 log = getLogger(__name__)
 
 
 def verify_ssh_agent_running():
+    """
+    Make sure the local machine has an SSH agent running
+    :return int exit_code: the exit code of the SSH agent verification command
+    """
     log.info("Verifying SSH agent is running on the local machine")
     verify_agent_command = ['ssh-add', '-l']
     exit_code, standard_out, _ = run_command_print_ready(
@@ -17,3 +22,26 @@ def verify_ssh_agent_running():
         )
     )
     return exit_code
+
+
+def get_ssh_connection(host_and_port_pairs):
+    """
+    Iterate over host and port pairs and try to connect over ssh on each
+    machine until one returns a nonzero exit code trying to run a command.
+    At that point return the host_and_port pair
+    :param list[tuple, ..] host_and_port_pairs: A list of tuples containing host and ports
+    :return tuple host_and_port_pair: host and port pair
+    """
+    log.debug(
+        "Finding the first available machine we can log in to"
+    )
+    check_connection_command = ["/bin/echo", "1"]
+    attempt_message = "Trying to get a shell on {}:{}"
+    all_failed_message = "Failed to get an SSH connection. No available."
+    _, host, port = try_machine_command(
+        host_and_port_pairs,
+        check_connection_command,
+        attempt_message=attempt_message,
+        all_failed_message=all_failed_message
+    )
+    return host, port

--- a/tests/unit/raptiformica/actions/ssh_connect/test_ssh_connect.py
+++ b/tests/unit/raptiformica/actions/ssh_connect/test_ssh_connect.py
@@ -1,0 +1,49 @@
+from raptiformica.actions.ssh_connect import ssh_connect
+from tests.testcase import TestCase
+
+
+class TestSSHConnect(TestCase):
+    def setUp(self):
+        self.host_and_port_pairs_from_mutable_config = self.set_up_patch(
+            'raptiformica.actions.ssh_connect.host_and_port_pairs_from_mutable_config'
+        )
+        self.get_ssh_connection = self.set_up_patch(
+            'raptiformica.actions.ssh_connect.get_ssh_connection'
+        )
+        self.system = self.set_up_patch(
+            'raptiformica.actions.ssh_connect.system'
+        )
+        self.print = self.set_up_patch(
+            'raptiformica.actions.ssh_connect.print'
+        )
+        self.get_ssh_connection.return_value = ('127.0.0.1', '22')
+
+    def test_ssh_connect_gets_host_and_port_pairs_from_mutable_config(self):
+        ssh_connect()
+
+        self.host_and_port_pairs_from_mutable_config.assert_called_once_with()
+
+    def test_ssh_connect_gets_ssh_connection_from_host_and_port_pairs(self):
+        ssh_connect()
+
+        self.get_ssh_connection.assert_called_once_with(
+            self.host_and_port_pairs_from_mutable_config.return_value
+        )
+
+    def test_ssh_connect_gets_system_shell_with_ssh_command(self):
+        ssh_connect()
+
+        self.system.assert_called_once_with(
+            'ssh root@127.0.0.1 -p 22 -oStrictHostKeyChecking=no '
+            '-oUserKnownHostsFile=/dev/null -oPasswordAuthentication=no'
+        )
+        self.assertFalse(self.print.called)
+
+    def test_ssh_connect_only_prints_ssh_command_if_info_only_is_specified(self):
+        ssh_connect(info_only=True)
+
+        self.assertFalse(self.system.called)
+        self.print.assert_called_once_with(
+            'ssh root@127.0.0.1 -p 22 -oStrictHostKeyChecking=no '
+            '-oUserKnownHostsFile=/dev/null -oPasswordAuthentication=no'
+        )

--- a/tests/unit/raptiformica/cli/test_parse_ssh_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_ssh_arguments.py
@@ -1,0 +1,42 @@
+from mock import call
+from raptiformica.cli import parse_ssh_arguments
+from tests.testcase import TestCase
+
+
+class TestParseSSHArguments(TestCase):
+    def setUp(self):
+        self.argument_parser = self.set_up_patch('raptiformica.cli.ArgumentParser')
+        self.parse_arguments = self.set_up_patch('raptiformica.cli.parse_arguments')
+
+    def test_parse_ssh_arguments_instantiates_argparser(self):
+        parse_ssh_arguments()
+
+        self.argument_parser.assert_called_once_with(
+            prog='raptiformica ssh',
+            description="SSH into one of the machines"
+        )
+
+    def test_parse_ssh_arguments_adds_arguments(self):
+        parse_ssh_arguments()
+
+        expected_calls = [
+            call(
+                '--info-only',
+                action='store_true',
+                help="Don't get a shell. Only print the command to connect."
+            ),
+        ]
+        self.assertEqual(
+            self.argument_parser.return_value.add_argument.mock_calls,
+            expected_calls
+        )
+
+    def test_parse_ssh_arguments_parses_arguments(self):
+        parse_ssh_arguments()
+
+        self.parse_arguments.assert_called_once_with(self.argument_parser.return_value)
+
+    def test_parse_ssh_arguments_returns_parsed_arguments(self):
+        ret = parse_ssh_arguments()
+
+        self.assertEqual(ret, self.parse_arguments.return_value)

--- a/tests/unit/raptiformica/cli/test_ssh.py
+++ b/tests/unit/raptiformica/cli/test_ssh.py
@@ -1,0 +1,20 @@
+from raptiformica.cli import ssh
+from tests.testcase import TestCase
+
+
+class TestSSH(TestCase):
+    def setUp(self):
+        self.parse_ssh_arguments = self.set_up_patch('raptiformica.cli.parse_ssh_arguments')
+        self.ssh_connect = self.set_up_patch('raptiformica.cli.ssh_connect')
+
+    def test_ssh_parses_ssh_arguments(self):
+        ssh()
+
+        self.parse_ssh_arguments.assert_called_once_with()
+
+    def test_ssh_shows_ssh(self):
+        ssh()
+
+        self.ssh_connect.assert_called_once_with(
+            info_only=self.parse_ssh_arguments.return_value.info_only
+        )

--- a/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
+++ b/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
@@ -10,12 +10,12 @@ class TestTryMachineCommand(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.distributed.exec.log')
         self.host_and_port_pairs = [
-            ('1.2.3.4', 2222),
-            ('5.6.7.8', 22),
-            ('9.9.9.9', 1222)
+            ('1.2.3.4', '2222'),
+            ('5.6.7.8', '22'),
+            ('9.9.9.9', '1222')
         ]
         self.execute_process = self.set_up_patch(
-                'raptiformica.shell.execute.execute_process'
+            'raptiformica.shell.execute.execute_process'
         )
         self.process_output = (1, 'standard out output', 'standard error output')
         self.execute_process.return_value = self.process_output
@@ -40,14 +40,23 @@ class TestTryMachineCommand(TestCase):
 
         try_machine_command(self.host_and_port_pairs, self.command)
 
-        expected_command_as_list1 = ['/usr/bin/env', 'ssh', '-o', 'StrictHostKeyChecking=no',
-                                     '-o', 'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+        expected_command_as_list1 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'StrictHostKeyChecking=no',
+                                     '-o', 'UserKnownHostsFile=/dev/null',
+                                     '-o', 'PasswordAuthentication=no',
+                                     'root@1.2.3.4',
                                      '-p', '2222', '/bin/true']
-        expected_command_as_list2 = ['/usr/bin/env', 'ssh', '-o', 'StrictHostKeyChecking=no',
-                                     '-o', 'UserKnownHostsFile=/dev/null', 'root@5.6.7.8',
+        expected_command_as_list2 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'StrictHostKeyChecking=no',
+                                     '-o', 'UserKnownHostsFile=/dev/null',
+                                     '-o', 'PasswordAuthentication=no',
+                                     'root@5.6.7.8',
                                      '-p', '22', '/bin/true']
-        expected_command_as_list3 = ['/usr/bin/env', 'ssh', '-o', 'StrictHostKeyChecking=no',
-                                     '-o', 'UserKnownHostsFile=/dev/null', 'root@9.9.9.9',
+        expected_command_as_list3 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'StrictHostKeyChecking=no',
+                                     '-o', 'UserKnownHostsFile=/dev/null',
+                                     '-o', 'PasswordAuthentication=no',
+                                     'root@9.9.9.9',
                                      '-p', '1222', '/bin/true']
         expected_command_list = [
             expected_command_as_list1,
@@ -66,7 +75,12 @@ class TestTryMachineCommand(TestCase):
 
         ret = try_machine_command(self.host_and_port_pairs, self.command)
 
-        self.assertEqual(ret, 'standard out output')
+        self.assertEqual(ret, ('standard out output', '9.9.9.9', '1222'))
+
+    def test_try_machine_command_returns_tuple_of_nones_if_no_remote_host_succeeded_running_the_command(self):
+        ret = try_machine_command(self.host_and_port_pairs, self.command)
+
+        self.assertEqual(ret, (None, None, None))
 
     def test_try_machine_command_warns_failed_when_no_remote_host_succeeded_running_the_command(self):
         try_machine_command(self.host_and_port_pairs, self.command)

--- a/tests/unit/raptiformica/distributed/members/test_try_get_members_list.py
+++ b/tests/unit/raptiformica/distributed/members/test_try_get_members_list.py
@@ -5,9 +5,10 @@ from tests.testcase import TestCase
 class TestTryGetMembersList(TestCase):
     def setUp(self):
         self.try_machine_command = self.set_up_patch('raptiformica.distributed.members.try_machine_command')
+        self.try_machine_command.return_value = ('output', '5.6.7.8', '22')
         self.host_and_port_pairs = [
-            ('1.2.3.4', 2222),
-            ('5.6.7.8', 22)
+            ('1.2.3.4', '2222'),
+            ('5.6.7.8', '22')
         ]
 
     def test_try_get_members_list_tries_machine_command(self):
@@ -22,3 +23,8 @@ class TestTryGetMembersList(TestCase):
                                "Maybe no meshnet has been established yet. "
                                "Do you have at least three machines running?"
         )
+
+    def test_try_get_members_list_returns_output_from_first_successful_members_list(self):
+        ret = try_get_members_list(self.host_and_port_pairs)
+
+        self.assertEqual(ret, 'output')

--- a/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
@@ -26,6 +26,7 @@ class TestCjdnsSetup(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             'bash', '-c', 'cd {} && {}'.format(
                 join(INSTALL_DIR, 'cjdns'),

--- a/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
@@ -20,6 +20,7 @@ class TestEnsureCjdnsDependencies(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             "sh", "-c",
             '"type pacman 1> /dev/null '
@@ -30,6 +31,7 @@ class TestEnsureCjdnsDependencies(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             "sh", "-c",
             '"type apt-get 1> /dev/null && '

--- a/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
@@ -17,6 +17,7 @@ class TestGetCjdnsConfigItem(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             'sh', '-c',
             '"cat /etc/cjdroute.conf | '
@@ -36,6 +37,7 @@ class TestGetCjdnsConfigItem(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2223',
             'sh', '-c',
             '"cat /etc/cjdroute.conf | '

--- a/tests/unit/raptiformica/shell/config/test_run_resource_command.py
+++ b/tests/unit/raptiformica/shell/config/test_run_resource_command.py
@@ -24,6 +24,7 @@ class TestRunResourceCommand(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             'cd', '/usr/etc/puppetfiles',
             ';', './papply.sh manifests/headless.pp'

--- a/tests/unit/raptiformica/shell/consul/test_consul_setup.py
+++ b/tests/unit/raptiformica/shell/consul/test_consul_setup.py
@@ -26,6 +26,7 @@ class TestConsulSetup(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             join(RAPTIFORMICA_DIR, 'resources/setup_consul.sh')
         ]

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
@@ -20,6 +20,7 @@ class TestEnsureConsulDependencies(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             "sh", "-c",
             '"type pacman 1> /dev/null '
@@ -30,6 +31,7 @@ class TestEnsureConsulDependencies(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             "sh", "-c",
             '"type apt-get 1> /dev/null && '

--- a/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
@@ -22,16 +22,20 @@ class TestEnsureLatestConsulRelease(TestCase):
         ensure_latest_consul_release('1.2.3.4', port=2222)
 
         expected_binary_command = [
-            '/usr/bin/env', 'ssh', '-o',
-            'StrictHostKeyChecking=no', '-o',
-            'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+            '/usr/bin/env', 'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
+            'root@1.2.3.4',
             '-p', '2222', 'wget', '-nc',
             'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip'
         ]
         expected_web_ui_command = [
-            '/usr/bin/env', 'ssh', '-o',
-            'StrictHostKeyChecking=no', '-o',
-            'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+            '/usr/bin/env', 'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
+            'root@1.2.3.4',
             '-p', '2222', 'wget', '-nc',
             'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_web_ui.zip'
         ]

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
@@ -20,9 +20,11 @@ class TestUnzipConsulBinary(TestCase):
         unzip_consul_binary('1.2.3.4', port=2222)
 
         expected_command = [
-            '/usr/bin/env', 'ssh', '-o',
-            'StrictHostKeyChecking=no', '-o',
-            'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+            '/usr/bin/env', 'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
+            'root@1.2.3.4',
             '-p', '2222', 'unzip', '-o',
             'consul_0.6.4_linux_amd64.zip',
             '-d', '/usr/bin'

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
@@ -20,9 +20,11 @@ class TestUnzipConsulWebUI(TestCase):
         unzip_consul_web_ui('1.2.3.4', port=2222)
 
         expected_command = [
-            '/usr/bin/env', 'ssh', '-o',
-            'StrictHostKeyChecking=no', '-o',
-            'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+            '/usr/bin/env', 'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
+            'root@1.2.3.4',
             '-p', '2222', 'unzip', '-o',
             'consul_0.6.4_web_ui.zip',
             '-d', '/usr/etc/consul_web_ui'

--- a/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
@@ -31,6 +31,7 @@ class TestCloneSourceRemotely(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@127.0.0.1', '-p', '2222',
             '/usr/bin/env', 'git', 'clone',
             'https://github.com/vdloo/puppetfiles',

--- a/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
+++ b/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
@@ -23,6 +23,7 @@ class TestPullOriginMaster(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '22',
             'cd', '/usr/etc/puppetfiles',

--- a/tests/unit/raptiformica/shell/git/test_reset_hard_origin_master.py
+++ b/tests/unit/raptiformica/shell/git/test_reset_hard_origin_master.py
@@ -23,6 +23,7 @@ class TestResetHardOriginMaster(TestCase):
            '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '22',
             'cd', '/usr/etc/puppetfiles',

--- a/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
@@ -20,8 +20,11 @@ class TestCreateRemoteRaptiformicaCache(TestCase):
         create_remote_raptiformica_cache('1.2.3.4', port=1234)
 
         expected_upload_command = [
-            '/usr/bin/env', 'ssh', '-o', 'StrictHostKeyChecking=no',
-            '-o', 'UserKnownHostsFile=/dev/null', 'root@1.2.3.4',
+            '/usr/bin/env', 'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
+            'root@1.2.3.4',
             '-p', '1234', 'mkdir', '-p', '$HOME/.raptiformica.d'
         ]
         self.execute_process.assert_called_once_with(

--- a/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
@@ -29,6 +29,7 @@ class TestRunRaptiformicaCommand(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
             'sh', '-c',
             '"cd /usr/etc/raptiformica; '

--- a/tests/unit/raptiformica/shell/ssh/test_get_ssh_connection.py
+++ b/tests/unit/raptiformica/shell/ssh/test_get_ssh_connection.py
@@ -1,0 +1,40 @@
+from mock import Mock
+
+from raptiformica.shell.ssh import get_ssh_connection
+from tests.testcase import TestCase
+
+
+class TestGetSSHConnection(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.shell.ssh.log')
+        self.host_and_port_pairs = [
+            ('1.1.1.1', '22'),
+            ('1.1.1.2', '2222'),
+            ('1.1.1.3', '2202'),
+        ]
+        self.try_machine_command = self.set_up_patch(
+            'raptiformica.shell.ssh.try_machine_command'
+        )
+        self.try_machine_command.return_value = ('1', '1.1.1.2', '2222')
+
+    def test_get_ssh_connection_logs_getting_ssh_connection_message(self):
+        get_ssh_connection(self.host_and_port_pairs)
+
+        self.assertTrue(self.log.debug.called)
+
+    def test_get_ssh_connection_tries_machine_echoing_in_remote_shell(self):
+        get_ssh_connection(self.host_and_port_pairs)
+
+        expected_command = ['/bin/echo', '1']
+        self.try_machine_command.assert_called_once_with(
+            self.host_and_port_pairs,
+            expected_command,
+            attempt_message="Trying to get a shell on {}:{}",
+            all_failed_message="Failed to get an SSH connection. No available."
+        )
+
+    def test_get_ssh_connection_returns_first_connecting_host_and_port(self):
+        host, port = get_ssh_connection(self.host_and_port_pairs)
+
+        self.assertEqual(host, '1.1.1.2')
+        self.assertEqual(port, '2222')

--- a/tests/unit/raptiformica/shell/ssh/test_verify_ssh_agent_running.py
+++ b/tests/unit/raptiformica/shell/ssh/test_verify_ssh_agent_running.py
@@ -2,11 +2,11 @@ from raptiformica.shell.ssh import verify_ssh_agent_running
 from tests.testcase import TestCase
 
 
-class TestVerifySshAgentRunning(TestCase):
+class TestVerifySSHAgentRunning(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.shell.ssh.log')
         self.execute_process = self.set_up_patch(
-                'raptiformica.shell.execute.execute_process'
+            'raptiformica.shell.execute.execute_process'
         )
         self.process_output = (0, 'standard out output', '')
         self.execute_process.return_value = self.process_output

--- a/tests/unit/raptiformica/shell/unzip/test_unzip.py
+++ b/tests/unit/raptiformica/shell/unzip/test_unzip.py
@@ -21,6 +21,7 @@ class TestUnzip(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '22',
             'unzip',

--- a/tests/unit/raptiformica/shell/wget/test_wget.py
+++ b/tests/unit/raptiformica/shell/wget/test_wget.py
@@ -21,6 +21,7 @@ class TestWget(TestCase):
             '/usr/bin/env', 'ssh',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '22',
             'wget', '-nc', 'https://www.example.com/some_url.zip'
         ]


### PR DESCRIPTION
Get the first available shell or print an ssh command to connect over ssh

```
$ raptiformica ssh
Warning: Permanently added '172.17.0.6' (ECDSA) to the list of known hosts.
root@379683bbc562:~# logout
Connection to 172.17.0.6 closed.
$ raptiformica ssh --info-only
ssh root@172.17.0.3 -p 22 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oPasswordAuthentication=no
```

Currently this is semi-random because python3 lists do not have order. That's fine. In the future I'd like to
implement filters that get you a shell on the 'fastest' machine in the cluster, or the first machine tagged with
'disposable' or something.