### PR TITLE
rejoin-members reloads peer information on disk

### DIFF
--- a/raptiformica/actions/members.py
+++ b/raptiformica/actions/members.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from raptiformica.actions.mesh import join_meshnet, configure_cjdroute_conf, configure_consul_conf
+from raptiformica.actions.mesh import join_meshnet, configure_cjdroute_conf, configure_consul_conf, ensure_cjdns_routing
 from raptiformica.distributed.discovery import host_and_port_pairs_from_mutable_config
 from raptiformica.distributed.members import try_get_members_list
 
@@ -25,4 +25,5 @@ def rejoin_members():
     """
     configure_cjdroute_conf()
     configure_consul_conf()
+    ensure_cjdns_routing()
     join_meshnet()

--- a/tests/unit/raptiformica/actions/members/test_rejoin_members.py
+++ b/tests/unit/raptiformica/actions/members/test_rejoin_members.py
@@ -10,9 +10,27 @@ class TestRejoinMembers(TestCase):
         self.configure_consul_conf = self.set_up_patch(
             'raptiformica.actions.members.configure_consul_conf'
         )
+        self.ensure_cjdns_routing = self.set_up_patch(
+            'raptiformica.actions.members.ensure_cjdns_routing'
+        )
         self.join_meshnet = self.set_up_patch(
             'raptiformica.actions.members.join_meshnet'
         )
+
+    def test_rejoin_members_configures_cjdroute_conf(self):
+        rejoin_members()
+
+        self.configure_cjdroute_conf.assert_called_once_with()
+
+    def test_rejoin_members_configures_consul_conf(self):
+        rejoin_members()
+
+        self.configure_consul_conf.assert_called_once_with()
+
+    def test_rejoin_members_ensures_cjdns_routing(self):
+        rejoin_members()
+
+        self.ensure_cjdns_routing.assert_called_once_with()
 
     def test_rejoin_members_joins_meshnet(self):
         rejoin_members()

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
@@ -1,0 +1,31 @@
+from raptiformica.actions.mesh import ensure_cjdns_routing
+from tests.testcase import TestCase
+
+
+class TestEnsureCjdnsRouting(TestCase):
+    def setUp(self):
+        self.start_detached_cjdroute = self.set_up_patch(
+            'raptiformica.actions.mesh.start_detached_cjdroute'
+        )
+        self.block_until_tun0_becomes_available = self.set_up_patch(
+            'raptiformica.actions.mesh.block_until_tun0_becomes_available'
+        )
+        self.ensure_ipv6_routing = self.set_up_patch(
+            'raptiformica.actions.mesh.ensure_ipv6_routing'
+        )
+
+    def test_ensure_cjdns_routing_starts_detached_cjdroute(self):
+        ensure_cjdns_routing()
+
+        self.start_detached_cjdroute.assert_called_once_with()
+
+    def test_ensure_cjdns_routing_blocks_until_tun0_becomes_available(self):
+        ensure_cjdns_routing()
+
+        self.block_until_tun0_becomes_available.assert_called_once_with()
+
+    def test_ensure_cjdns_routing_ensure_ipv6_routing(self):
+        ensure_cjdns_routing()
+
+        self.ensure_ipv6_routing.assert_called_once_with()
+

--- a/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
@@ -19,7 +19,10 @@ class TestStartDetachedCjdroute(TestCase):
     def test_start_detached_cjdroute_starts_detached_cjdroute(self):
         start_detached_cjdroute()
 
-        expected_command = "/usr/bin/env screen -d -m bash -c 'cat {} | cjdroute --nobg'".format(CJDROUTE_CONF_PATH)
+        expected_command = "pkill -f 'cjdroute --nobg'; " \
+                           "/usr/bin/env screen -d -m bash -c '" \
+                           "cat {} | cjdroute --nobg" \
+                           "'".format(CJDROUTE_CONF_PATH)
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,

--- a/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_meshing_services.py
@@ -5,12 +5,12 @@ from tests.testcase import TestCase
 class TestStartMeshingServices(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
-        self.start_detached_cjdroute = self.set_up_patch('raptiformica.actions.mesh.start_detached_cjdroute')
-        self.block_until_tun0_becomes_available = self.set_up_patch(
-            'raptiformica.actions.mesh.block_until_tun0_becomes_available'
+        self.ensure_cjdns_routing = self.set_up_patch(
+            'raptiformica.actions.mesh.ensure_cjdns_routing'
         )
-        self.ensure_ipv6_routing = self.set_up_patch('raptiformica.actions.mesh.ensure_ipv6_routing')
-        self.start_detached_consul_agent = self.set_up_patch('raptiformica.actions.mesh.start_detached_consul_agent')
+        self.start_detached_consul_agent = self.set_up_patch(
+            'raptiformica.actions.mesh.start_detached_consul_agent'
+        )
         self.block_until_consul_becomes_available = self.set_up_patch(
             'raptiformica.actions.mesh.block_until_consul_becomes_available'
         )
@@ -20,20 +20,10 @@ class TestStartMeshingServices(TestCase):
 
         self.log.info.assert_called_once_with("Starting meshing services")
 
-    def test_start_meshing_services_starts_detached_cjdroute(self):
+    def test_start_meshing_services_ensures_cjdns_routing(self):
         start_meshing_services()
 
-        self.start_detached_cjdroute.assert_called_once_with()
-
-    def test_start_meshing_services_blocks_until_tun0_becomes_available(self):
-        start_meshing_services()
-
-        self.block_until_tun0_becomes_available.assert_called_once_with()
-
-    def test_start_meshing_services_ensure_ipv6_routing(self):
-        start_meshing_services()
-
-        self.ensure_ipv6_routing.assert_called_once_with()
+        self.ensure_cjdns_routing.assert_called_once_with()
 
     def test_start_meshing_services_starts_detached_consul_agent(self):
         start_meshing_services()


### PR DESCRIPTION
instead of only joining the new members in the mesh with `consul join`
now also the consul config file and the cjdns config file will be
re-generated. previously running cjdroute instances will be killed if
`start_detached_cjdroute` is run. rejoin now also runs
`start_detached_cjdroute`.