### PR TITLE
cjdroute is stored as an artifact

### DIFF
--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -10,7 +10,7 @@ from raptiformica.shell.consul import ensure_consul_installed
 from raptiformica.shell.git import ensure_latest_source
 from raptiformica.shell.hooks import fire_hooks
 from raptiformica.shell.raptiformica import mesh
-from raptiformica.shell.rsync import upload_self
+from raptiformica.shell.rsync import upload_self, download_artifacts
 from raptiformica.utils import endswith, startswith
 
 log = getLogger(__name__)
@@ -74,6 +74,7 @@ def assimilate_machine(host, port=22, uuid=None):
     log.info("Preparing to machine to be joined into the distributed network")
     ensure_cjdns_installed(host, port=port)
     ensure_consul_installed(host, port=port)
+    download_artifacts(host, port=port)
     update_meshnet_config(host, port=port, compute_checkout_uuid=uuid)
 
 

--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -1,13 +1,43 @@
 from functools import partial
 from logging import getLogger
 
-from os.path import isfile, isdir
+from os.path import isdir, join
 
-from raptiformica.settings import PROJECT_DIR, INSTALL_DIR, MUTABLE_CONFIG, USER_MODULES_DIR, ABS_CACHE_DIR
+from raptiformica.settings import PROJECT_DIR, INSTALL_DIR, ABS_CACHE_DIR, CACHE_DIR
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory, log_success_factory
 from raptiformica.shell.raptiformica import create_remote_raptiformica_cache
 
 log = getLogger(__name__)
+
+
+def download(source, destination, host, port=22):
+    """
+    Upload the source path from the local host to the destination path on the remote host
+    :param str source: path to sync from on the local host
+    :param str destination: path to sync to on the remote machine
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :return bool status: success or failure
+    """
+    download_command = [
+        '/usr/bin/env', 'rsync', '-L', '-avz',
+        'root@{}:{}'.format(host, source), destination,
+        '--exclude=.venv', '--exclude=*.pyc',
+        '-e', 'ssh -p {} '
+              '-oStrictHostKeyChecking=no '
+              '-oUserKnownHostsFile=/dev/null'.format(port)
+    ]
+    exit_code, _, _ = run_command_print_ready(
+        download_command,
+        success_callback=log_success_factory(
+            "Successfully downloaded files from the remote host"
+        ),
+        failure_callback=raise_failure_factory(
+            "Something went wrong downloading files from the remote host"
+        ),
+        buffered=False
+    )
+    return exit_code
 
 
 def upload(source, destination, host, port=22):
@@ -63,3 +93,20 @@ def upload_self(host, port=22):
             upload_config_exit_code
         )
     )
+
+
+def download_artifacts(host, port=22):
+    """
+    If new artifacts were created copy those back to this machine so that
+    if we ever need to do something on a similar machine again later we don't
+    have to do double work
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :return bool status: True if success, False if failure
+    """
+    log.info("Downloading artifacts from the remote host")
+    download_partial = partial(download, host=host, port=port)
+    download_artifacts_exit_code = download_partial(
+        join(CACHE_DIR, 'artifacts'), ABS_CACHE_DIR
+    )
+    return not download_artifacts_exit_code

--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -3,8 +3,20 @@ set -e
 echo "changing directory to /usr/etc/cjdns"
 cd /usr/etc/cjdns
 
+echo "Checking for a pre-compiled cjdroute"
+
 echo "ensuring binary is compiled"
-[ ! -f cjdroute ] && ./do
+if [ ! -f cjdroute ]; then
+    if [ -f ~/.raptiformica.d/artifacts/$(arch)/cjdns/cjdroute ]; then
+        echo 'using stored artifact'
+        cp ~/.raptiformica.d/artifacts/$(arch)/cjdns/cjdroute .
+    else
+        echo 'compiling new cjdoute'
+        ./do
+        mkdir -p ~/.raptiformica.d/artifacts/$(arch)/cjdns/
+        cp -f cjdroute ~/.raptiformica.d/artifacts/$(arch)/cjdns/
+    fi
+fi
 
 echo "ensuring tun device exists"
 if cat /dev/net/tun | grep -q "File descriptor in bad state" ; then
@@ -20,8 +32,8 @@ else
 fi
 
 echo "ensuring binary and config to /usr/bin"
-cp cjdroute /usr/bin/
-cp cjdroute.conf /etc/
+cp -f cjdroute /usr/bin/
+cp -f cjdroute.conf /etc/
 
 if [ -d /etc/systemd ]; then
     echo "installing cjdns service file"

--- a/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
@@ -1,4 +1,4 @@
-from raptiformica.actions.mesh import stop_detached_cjdroute, CJDROUTE_CONF_PATH
+from raptiformica.actions.mesh import stop_detached_cjdroute
 from tests.testcase import TestCase
 
 

--- a/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
@@ -7,6 +7,7 @@ class TestAssimilateMachine(TestCase):
         self.log = self.set_up_patch('raptiformica.actions.slave.log')
         self.ensure_cjdns_installed = self.set_up_patch('raptiformica.actions.slave.ensure_cjdns_installed')
         self.ensure_consul_installed = self.set_up_patch('raptiformica.actions.slave.ensure_consul_installed')
+        self.download_artifacts = self.set_up_patch('raptiformica.actions.slave.download_artifacts')
         self.update_meshnet_config = self.set_up_patch('raptiformica.actions.slave.update_meshnet_config')
 
     def test_assimilate_machine_logs_assimilating_machine_message(self):
@@ -23,6 +24,11 @@ class TestAssimilateMachine(TestCase):
         assimilate_machine('1.2.3.4', port=2222)
 
         self.ensure_consul_installed.assert_called_once_with('1.2.3.4', port=2222)
+
+    def test_assimilate_machine_downloads_artifacts(self):
+        assimilate_machine('1.2.3.4', port=2222)
+
+        self.download_artifacts.assert_called_once_with('1.2.3.4', port=2222)
 
     def test_assimilate_machine_updates_meshnet_config(self):
         assimilate_machine('1.2.3.4', port=2222)

--- a/tests/unit/raptiformica/shell/rsync/test_download.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download.py
@@ -1,9 +1,9 @@
 from raptiformica.settings import PROJECT_DIR, INSTALL_DIR
-from raptiformica.shell.rsync import upload
+from raptiformica.shell.rsync import download
 from tests.testcase import TestCase
 
 
-class TestUpload(TestCase):
+class TestDownload(TestCase):
     def setUp(self):
         self.execute_process = self.set_up_patch(
             'raptiformica.shell.execute.execute_process'
@@ -11,31 +11,31 @@ class TestUpload(TestCase):
         self.process_output = (0, 'standard out output', '')
         self.execute_process.return_value = self.process_output
 
-    def test_upload_runs_upload_command(self):
-        upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+    def test_download_runs_download_command(self):
+        download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
 
-        expected_upload_command = [
-            '/usr/bin/env', 'rsync', '-L', '-avz', PROJECT_DIR,
-            'root@1.2.3.4:{}'.format(INSTALL_DIR), '--exclude=.venv',
-            '--exclude=*.pyc', '--exclude=var', '-e',
-            'ssh -p 22 '
+        expected_download_command = [
+            '/usr/bin/env', 'rsync', '-L', '-avz',
+            'root@1.2.3.4:{}'.format(PROJECT_DIR),
+            INSTALL_DIR, '--exclude=.venv',
+            '--exclude=*.pyc', '-e', 'ssh -p 22 '
             '-oStrictHostKeyChecking=no '
             '-oUserKnownHostsFile=/dev/null'
         ]
         self.execute_process.assert_called_once_with(
-            expected_upload_command,
+            expected_download_command,
             buffered=False,
             shell=False
         )
 
-    def test_upload_raises_error_when_uploading_failed(self):
+    def test_download_raises_error_when_downloading_failed(self):
         self.process_output = (1, '', 'standard error output')
         self.execute_process.return_value = self.process_output
 
         with self.assertRaises(RuntimeError):
-            upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+            download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
 
-    def test_upload_returns_command_exit_code(self):
-        ret = upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+    def test_download_returns_command_exit_code(self):
+        ret = download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
@@ -1,0 +1,37 @@
+from raptiformica.settings import ABS_CACHE_DIR
+from raptiformica.shell.rsync import download_artifacts
+from tests.testcase import TestCase
+
+
+class TestDownloadArtifacts(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.shell.rsync.log')
+        self.download = self.set_up_patch('raptiformica.shell.rsync.download')
+        self.download.return_value = 0
+
+    def test_download_artifacts_logs_downloading_artifacts_message(self):
+        download_artifacts('1.2.3.4', port=2222)
+
+        self.assertTrue(self.log.info.called)
+
+    def test_download_artifacts_downloads_artifacts_from_remote_host(self):
+        download_artifacts('1.2.3.4', port=2222)
+
+        self.download.assert_called_once_with(
+            '.raptiformica.d/artifacts',
+            ABS_CACHE_DIR,
+            host='1.2.3.4',
+            port=2222
+        )
+
+    def test_download_artifacts_returns_true_if_success(self):
+        ret = download_artifacts('1.2.3.4', port=2222)
+
+        self.assertTrue(ret)
+
+    def test_download_artifacts_returns_false_if_failure(self):
+        self.download.return_value = 1
+
+        ret = download_artifacts('1.2.3.4', port=2222)
+
+        self.assertFalse(ret)

--- a/tests/unit/raptiformica/shell/rsync/test_upload_self.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload_self.py
@@ -1,6 +1,6 @@
 from mock import call
 
-from raptiformica.settings import INSTALL_DIR, MUTABLE_CONFIG, ABS_CACHE_DIR
+from raptiformica.settings import INSTALL_DIR, ABS_CACHE_DIR
 from raptiformica.settings import PROJECT_DIR
 from raptiformica.shell.rsync import upload_self
 from tests.testcase import TestCase


### PR DESCRIPTION
so machines with the same architecture do not have to compile it themselves