### PR TITLE
default provisioning runs command on local machine

### DIFF
--- a/modules/server/default.json
+++ b/modules/server/default.json
@@ -4,7 +4,7 @@
     "headless": {
       "raptiformica": {
         "source": "https://github.com/vdloo/raptiformica",
-        "bootstrap": "cat /dev/zero | ssh-keygen -f loopback -q -N '' > /dev/null 2>&1; eval $(ssh-agent -s); ssh-add loopback; cat loopback.pub >> ~/.ssh/authorized_keys; export PYTHONPATH=/usr/etc/raptiformica; ./modules/server/deploy.py"
+        "bootstrap": "export PYTHONPATH=/usr/etc/raptiformica; ./modules/server/deploy.py"
       }
     }
   }

--- a/modules/server/deploy.py
+++ b/modules/server/deploy.py
@@ -11,10 +11,8 @@ def main():
     :return None:
     """
     setup_logging()
-    # todo: refactor this so that the shell commands below run on the local
-    # host directly, instead of SSHing to the localhost and running it there
-    ensure_cjdns_installed('localhost')
-    ensure_consul_installed('localhost')
+    ensure_cjdns_installed()
+    ensure_consul_installed()
 
 if __name__ == '__main__':
     main()

--- a/raptiformica/actions/modules.py
+++ b/raptiformica/actions/modules.py
@@ -5,7 +5,7 @@ from shutil import rmtree
 
 from raptiformica.settings import USER_MODULES_DIR
 from raptiformica.settings.load import on_disk_mapping, try_delete_config, try_update_config
-from raptiformica.shell.git import clone_source_locally
+from raptiformica.shell.git import clone_source
 
 log = getLogger(__name__)
 
@@ -36,7 +36,7 @@ def retrieve_module(module_name):
     log.info("Checking out {}".format(module_name))
     url, directory = determine_clone_data(module_name)
     log.debug("Cloning from {}".format(url))
-    clone_source_locally(
+    clone_source(
         url,
         join(USER_MODULES_DIR, directory)
     )

--- a/raptiformica/distributed/exec.py
+++ b/raptiformica/distributed/exec.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from raptiformica.shell.execute import run_command_remotely_print_ready
+from raptiformica.shell.execute import run_command_print_ready
 
 log = getLogger(__name__)
 
@@ -20,8 +20,8 @@ def try_machine_command(host_and_port_pairs, command_as_list,
     """
     for host, port in host_and_port_pairs:
         log.debug(attempt_message.format(host, port))
-        exit_code, standard_out_output, _ = run_command_remotely_print_ready(
-            command_as_list, host, port=port
+        exit_code, standard_out_output, _ = run_command_print_ready(
+            command_as_list, host=host, port=port
         )
         if exit_code == 0:
             return standard_out_output.strip(), host, port

--- a/raptiformica/shell/compute.py
+++ b/raptiformica/shell/compute.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from raptiformica.settings import EPHEMERAL_DIR, MACHINES_DIR
 from raptiformica.shell.execute import log_success_factory, raise_failure_factory, \
     run_command_print_ready_in_directory_factory, run_command_in_directory_factory
-from raptiformica.shell.git import clone_source_locally
+from raptiformica.shell.git import clone_source
 from raptiformica.utils import ensure_directory
 
 log = getLogger(__name__)
@@ -38,7 +38,7 @@ def create_new_compute_checkout(server_type, compute_type, source):
         server_type, compute_type
     )
     new_compute_checkout = path.join(server_type_directory, uuid4().hex)
-    clone_source_locally(source, new_compute_checkout)
+    clone_source(source, new_compute_checkout)
     return new_compute_checkout
 
 

--- a/raptiformica/shell/config.py
+++ b/raptiformica/shell/config.py
@@ -2,7 +2,7 @@ from os import path
 from logging import getLogger
 
 from raptiformica.settings import INSTALL_DIR
-from raptiformica.shell.execute import run_command_remotely_print_ready, log_failure_factory, log_success_factory
+from raptiformica.shell.execute import log_failure_factory, log_success_factory, run_command_print_ready
 
 log = getLogger(__name__)
 
@@ -21,8 +21,8 @@ def run_resource_command(command, name, host, port=22):
     configured_resource_command = [
         "cd", provisioning_directory, ";", command
     ]
-    exit_code, _, _ = run_command_remotely_print_ready(
-        configured_resource_command, host, port=port,
+    exit_code, _, _ = run_command_print_ready(
+        configured_resource_command, host=host, port=port,
         failure_callback=log_failure_factory(
             "Failed to run resource command"
         ),

--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -2,8 +2,7 @@ from os import path
 from logging import getLogger
 
 from raptiformica.settings import RAPTIFORMICA_DIR, CONSUL_WEB_UI_DIR
-from raptiformica.shell.execute import run_critical_unbuffered_command_remotely_print_ready, \
-    run_remote_multiple_labeled_commands
+from raptiformica.shell.execute import run_remote_multiple_labeled_commands, run_critical_unbuffered_command_print_ready
 from raptiformica.shell.unzip import unzip
 from raptiformica.shell.wget import wget
 
@@ -13,11 +12,11 @@ CONSUL_RELEASE = 'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux
 CONSUL_WEB_UI_RELEASE = 'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_web_ui.zip'
 
 
-def ensure_consul_dependencies(host, port=22):
+def ensure_consul_dependencies(host=None, port=22):
     """
     Install consul dependencies. Each command in the loop should check for identifiers of a
     certain distro and then run the idempotent install command if that distro is detected.
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
@@ -31,16 +30,16 @@ def ensure_consul_dependencies(host, port=22):
                    'apt-get install -yy wget unzip screen) || /bin/true"')
     )
     run_remote_multiple_labeled_commands(
-        ensure_consul_dependencies_commands, host, port=port,
+        ensure_consul_dependencies_commands, host=host, port=port,
         failure_message="Failed to run (if {}) install consul "
                         "dependencies command"
     )
 
 
-def ensure_latest_consul_release(host, port=22):
+def ensure_latest_consul_release(host=None, port=22):
     """
     Make sure the latest consul release is downloaded on the remote machine
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
@@ -48,30 +47,30 @@ def ensure_latest_consul_release(host, port=22):
              "on the remote machine".format(CONSUL_RELEASE.split('/')[-1]))
     for url in (CONSUL_RELEASE, CONSUL_WEB_UI_RELEASE):
         wget(
-            url, host, port=port,
+            url, host=host, port=port,
             failure_message="Failed to retrieve {}".format(url.split('/')[-1])
         )
 
 
-def unzip_consul_binary(host, port=22):
+def unzip_consul_binary(host=None, port=22):
     """
     Unzip the consul binary to /usr/bin
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
     log.info("Making sure the consul binary is placed in /usr/bin")
     unzip(
         CONSUL_RELEASE.split('/')[-1], '/usr/bin',
-        host, port=port,
+        host=host, port=port,
         failure_message="Failed to unpack the consul binary"
     )
 
 
-def unzip_consul_web_ui(host, port=22):
+def unzip_consul_web_ui(host=None, port=22):
     """
     Unzip the consul web_ui to /usr/etc/consul_web_ui
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
@@ -84,44 +83,44 @@ def unzip_consul_web_ui(host, port=22):
     )
 
 
-def unzip_consul_release(host, port=22):
+def unzip_consul_release(host=None, port=22):
     """
     Unzip the consul binary to /usr/bin and the web_ui to the INSTALL_DIR
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
-    unzip_consul_binary(host, port=port)
-    unzip_consul_web_ui(host, port=port)
+    unzip_consul_binary(host=host, port=port)
+    unzip_consul_web_ui(host=host, port=port)
 
 
-def consul_setup(host, port=22):
+def consul_setup(host=None, port=22):
     """
     Run the consul setup script. Places the systemd service file.
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return int exit_code: exit code of the configured bootstrap command
     """
     log.info("Build, configure and install CJDNS")
     setup_script = path.join(RAPTIFORMICA_DIR, 'resources/setup_consul.sh')
     cjdns_setup_command = [setup_script]
-    exit_code, _, _ = run_critical_unbuffered_command_remotely_print_ready(
-        cjdns_setup_command, host, port=port,
+    exit_code, _, _ = run_critical_unbuffered_command_print_ready(
+        cjdns_setup_command, host=host, port=port,
         failure_message="Failed to ensure that consul was configured"
     )
     return exit_code
 
 
-def ensure_consul_installed(host, port=22):
+def ensure_consul_installed(host=None, port=22):
     """
     Install consul. This is done with scripting instead of puppet for ansible because at this point in the code
     no guarantees can be made about the remote host's environment.
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
     log.info("Ensuring consul is installed")
-    ensure_consul_dependencies(host, port=port)
-    ensure_latest_consul_release(host, port=port)
-    unzip_consul_release(host, port=port)
-    consul_setup(host, port=port)
+    ensure_consul_dependencies(host=host, port=port)
+    ensure_latest_consul_release(host=host, port=port)
+    unzip_consul_release(host=host, port=port)
+    consul_setup(host=host, port=port)

--- a/raptiformica/shell/git.py
+++ b/raptiformica/shell/git.py
@@ -3,8 +3,8 @@ from os import path
 from logging import getLogger
 
 from raptiformica.settings import INSTALL_DIR
-from raptiformica.shell.execute import run_command_remotely, run_command_remotely_print_ready, run_command_print_ready, \
-    log_failure_factory
+from raptiformica.shell.execute import run_command_print_ready, \
+    log_failure_factory, run_command
 
 log = getLogger(__name__)
 
@@ -27,38 +27,28 @@ def execute_clone_source_command(url, directory, run_command_function):
     return exit_code
 
 
-def clone_source_locally(url, directory):
+def clone_source(url, directory, host=None, port=22):
     """
-    Clone a repository to a directory on the local host
-    :param str url: url to the repository to clone
-    :param str directory: directory to clone it to
-    :return int exit_code: exit code of the clone source command
-    """
-    return execute_clone_source_command(url, directory, run_command_print_ready)
-
-
-def clone_source_remotely(url, directory, host, port=22):
-    """
-    Clone a repository to a directory on the remote host
-    :param str host: hostname or ip of the remote machine
+    Clone a repository to a directory on the specified host
+    :param str host: hostname or ip of the remote machine, None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :param str url: url to the repository to clone
     :param str directory: directory to clone it to
     :return int exit_code: exit code of the clone source command
     """
-    run_command_remotely_print_ready_partial = partial(
-        run_command_remotely_print_ready, host=host, port=port
+    run_command_print_ready_partial = partial(
+        run_command_print_ready, host=host, port=port
     )
     return execute_clone_source_command(
-        url, directory, run_command_remotely_print_ready_partial
+        url, directory, run_command_print_ready_partial
     )
 
 
-def pull_origin_master(directory, host, port=22):
+def pull_origin_master(directory, host=None, port=22):
     """
     Pull origin master in a directory on the remote machine
     :param str directory: directory on the remote machine to pull origin master in
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return int exit_code: exit code of the remote command
     """
@@ -67,8 +57,8 @@ def pull_origin_master(directory, host, port=22):
         'cd', directory, ';',
         '/usr/bin/env', 'git', 'pull', 'origin', 'master'
     ]
-    exit_code, _, _ = run_command_remotely_print_ready(
-        pull_origin_master_command, host, port=port,
+    exit_code, _, _ = run_command_print_ready(
+        pull_origin_master_command, host=host, port=port,
         failure_callback=log_failure_factory(
             "Failed to pull origin master"
         )
@@ -76,11 +66,11 @@ def pull_origin_master(directory, host, port=22):
     return exit_code
 
 
-def reset_hard_origin_master(directory, host, port=22):
+def reset_hard_origin_master(directory, host=None, port=22):
     """
     Reset a checkout to the trunk of the repository
     :param str directory: directory on the remote machine to reset hard origin master in
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for local
     :param int port: port to use to connect to the remote machine over ssh
     :return int exit_code: exit code of the remote command
     """
@@ -89,8 +79,8 @@ def reset_hard_origin_master(directory, host, port=22):
         'cd', directory, ';',
         '/usr/bin/env', 'git', 'reset', '--hard', 'origin/master'
     ]
-    exit_code, _, _ = run_command_remotely_print_ready(
-        reset_hard_origin_master_command, host, port=port,
+    exit_code, _, _ = run_command_print_ready(
+        reset_hard_origin_master_command, host=host, port=port,
         failure_callback=log_failure_factory(
             "Failed to reset --hard origin/master"
         )
@@ -98,57 +88,57 @@ def reset_hard_origin_master(directory, host, port=22):
     return exit_code
 
 
-def update_source(directory, host, port=22):
+def update_source(directory, host=None, port=22):
     """
     Refresh a checked out repository
     :param str directory: directory to pull origin master and reset hard in
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
     log.info("Updating the repository in {}".format(directory))
-    exit_code = pull_origin_master(directory, host, port=port)
+    exit_code = pull_origin_master(directory, host=host, port=port)
     if exit_code != 0:
-        reset_hard_origin_master(directory, host, port=port)
+        reset_hard_origin_master(directory, host=host, port=port)
 
 
-def ensure_latest_source_failure_factory(source, provisioning_directory, host, port=22):
+def ensure_latest_source_failure_factory(source, provisioning_directory, host=None, port=22):
     """
-    Create a run_command callback that checks out a repository on the remote host
+    Create a run_command callback that checks out a repository on the specified host
     :param str source: repository to clone
     :param str provisioning_directory: directory where the repo will be cloned
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local host
     :param int port: port to use to connect to the remote machine over ssh
     :return function ensure_latest_source_failure: function that takes a process_output
     """
     def ensure_latest_source_failure(_):
         log.info("Provisioning directory does not exist yet")
-        clone_source_remotely(source, provisioning_directory, host, port=port)
+        clone_source(source, provisioning_directory, host=host, port=port)
     return ensure_latest_source_failure
 
 
-def ensure_latest_source_success_factory(provisioning_directory, host, port=22):
+def ensure_latest_source_success_factory(provisioning_directory, host=None, port=22):
     """
     Create a run_command callback that updates the provisioning_directory
-    on the remote host
+    on the specified host
     :param str provisioning_directory: directory of the checkout to be refreshed
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return function ensure_latest_source_success: function that takes a process_output
     """
     def ensure_latest_source_success(_):
-        log.info("Found an existing checkout on the remote host.")
-        update_source(provisioning_directory, host, port=port)
+        log.info("Found an existing checkout on the specified host.")
+        update_source(provisioning_directory, host=host, port=port)
     return ensure_latest_source_success
 
 
-def ensure_latest_source(source, name, host, port=22):
+def ensure_latest_source(source, name, host=None, port=22):
     """
     Ensure a repository is checked out and the latest version in the name directory
-    in the INSTALL DIR on a remote machine
+    in the INSTALL DIR on the specified machine
     :param source: location of the the source (url)
     :param name: name of the source
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :return int checkout_exists: exit code of the test -d command for the directory
     0 if the repository was freshly cloned,
@@ -158,13 +148,13 @@ def ensure_latest_source(source, name, host, port=22):
     provisioning_directory = path.join(INSTALL_DIR, name)
     test_directory_exists_command = ['test', '-d', provisioning_directory]
 
-    exit_code, _, _ = run_command_remotely(
-        test_directory_exists_command, host, port=port,
+    exit_code, _, _ = run_command(
+        test_directory_exists_command, host=host, port=port,
         success_callback=ensure_latest_source_success_factory(
-            provisioning_directory, host, port=port
+            provisioning_directory, host=host, port=port
         ),
         failure_callback=ensure_latest_source_failure_factory(
-            source, provisioning_directory, host, port=port
+            source, provisioning_directory, host=host, port=port
         )
     )
     return exit_code

--- a/raptiformica/shell/raptiformica.py
+++ b/raptiformica/shell/raptiformica.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 from raptiformica.settings import RAPTIFORMICA_DIR, CACHE_DIR
-from raptiformica.shell.execute import raise_failure_factory, run_command_remotely_print_ready, run_command_remotely
+from raptiformica.shell.execute import raise_failure_factory, run_command_remotely, run_command_print_ready
 
 log = getLogger(__name__)
 
@@ -31,11 +31,11 @@ def run_raptiformica_command(command_as_string, host, port=22):
     """
     log.info("Running raptiformica command on "
              "remote host: {}".format(command_as_string))
-    exit_code, _, _ = run_command_remotely_print_ready(
+    exit_code, _, _ = run_command_print_ready(
         ['sh', '-c', '"cd {}; {}"'.format(
             RAPTIFORMICA_DIR, command_as_string
         )],
-        host, port=port,
+        host=host, port=port,
         failure_callback=raise_failure_factory(
             "Failed to run raptiformica command on remote host"
         ),

--- a/raptiformica/shell/unzip.py
+++ b/raptiformica/shell/unzip.py
@@ -1,18 +1,18 @@
-from raptiformica.shell.execute import run_critical_unbuffered_command_remotely_print_ready
+from raptiformica.shell.execute import run_critical_unbuffered_command_print_ready
 
 
-def unzip(zip_file, unpack_dir, host, port=22, failure_message="Failed to unzip file"):
+def unzip(zip_file, unpack_dir, host=None, port=22, failure_message="Failed to unzip file"):
     """
     Unzip a file on the remote host
     :param str zip_file: path to the zip file to unzip
     :param str unpack_dir: path to the unpack directory
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :param str failure_message: Message to error out with if file could not
     be unzipped
     :return None:
     """
-    run_critical_unbuffered_command_remotely_print_ready(
+    run_critical_unbuffered_command_print_ready(
         ['unzip', '-o', zip_file, '-d', unpack_dir],
-        host, port=port, failure_message=failure_message
+        host=host, port=port, failure_message=failure_message
     )

--- a/raptiformica/shell/wget.py
+++ b/raptiformica/shell/wget.py
@@ -1,18 +1,18 @@
-from raptiformica.shell.execute import run_critical_unbuffered_command_remotely_print_ready
+from raptiformica.shell.execute import run_critical_unbuffered_command_print_ready
 
 
-def wget(url, host, port=22, failure_message='Failed retrieving file'):
+def wget(url, host=None, port=22, failure_message='Failed retrieving file'):
     """
     Download a file on the remote host
     The wget command use --no-clobber so it is idempotent
     :param url: the url to wget
-    :param str host: hostname or ip of the remote machine
+    :param str host: hostname or ip of the remote machine, or None for the local machine
     :param int port: port to use to connect to the remote machine over ssh
     :param str failure_message: Message to error out with if file could not
     be retrieved
     :return None:
     """
-    run_critical_unbuffered_command_remotely_print_ready(
-        ['wget', '-nc', url], host, port=port,
+    run_critical_unbuffered_command_print_ready(
+        ['wget', '-nc', url], host=host, port=port,
         failure_message=failure_message
     )

--- a/tests/unit/raptiformica/actions/modules/test_retrieve_module.py
+++ b/tests/unit/raptiformica/actions/modules/test_retrieve_module.py
@@ -17,8 +17,8 @@ class TestRetrieveModule(TestCase):
                 'puppetfiles'
             )
         )
-        self.clone_source_locally = self.set_up_patch(
-            'raptiformica.actions.modules.clone_source_locally'
+        self.clone_source = self.set_up_patch(
+            'raptiformica.actions.modules.clone_source'
         )
 
     def test_retrieve_module_logs_info_message(self):
@@ -41,7 +41,7 @@ class TestRetrieveModule(TestCase):
     def test_retrieve_module_clones_source_to_user_modules_dir(self):
         retrieve_module('vdloo/puppetfiles')
 
-        self.clone_source_locally.assert_called_once_with(
+        self.clone_source.assert_called_once_with(
             'https://github.com/vdloo/puppetfiles',
             join(USER_MODULES_DIR, 'puppetfiles')
         )

--- a/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_installed.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_installed.py
@@ -10,30 +10,32 @@ class TestEnsureCjdnsInstalled(TestCase):
         self.cjdns_setup = self.set_up_patch('raptiformica.shell.cjdns.cjdns_setup')
 
     def test_ensure_cjdns_installed_logs_installing_cjdns_message(self):
-        ensure_cjdns_installed('1.2.3.4', port=2222)
+        ensure_cjdns_installed(host='1.2.3.4', port=2222)
 
         self.assertTrue(self.log.info.called)
 
     def test_ensure_cjdns_installed_ensures_latest_source(self):
-        ensure_cjdns_installed('1.2.3.4', port=2222)
+        ensure_cjdns_installed(host='1.2.3.4', port=2222)
 
         self.ensure_latest_source.assert_called_once_with(
             CJDNS_REPOSITORY,
             "cjdns",
-            '1.2.3.4',
+            host='1.2.3.4',
             port=2222
         )
 
     def test_ensure_cjdns_installed_ensures_cjdns_dependencies(self):
-        ensure_cjdns_installed('1.2.3.4', port=2222)
+        ensure_cjdns_installed(host='1.2.3.4', port=2222)
 
         self.ensure_cjdns_dependencies.assert_called_once_with(
-            '1.2.3.4',
+            host='1.2.3.4',
             port=2222
         )
 
     def test_ensure_cjdns_installed_sets_up_cjdns(self):
-        ensure_cjdns_installed('1.2.3.4', port=2222)
+        ensure_cjdns_installed(host='1.2.3.4', port=2222)
 
-        self.cjdns_setup.assert_called_once_with('1.2.3.4', port=2222)
+        self.cjdns_setup.assert_called_once_with(
+            host='1.2.3.4', port=2222
+        )
 

--- a/tests/unit/raptiformica/shell/cjdns/test_get_ipv6_address.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_get_ipv6_address.py
@@ -8,18 +8,18 @@ class TestGetIpv6Address(TestCase):
         self.get_cjdns_config_item = self.set_up_patch('raptiformica.shell.cjdns.get_cjdns_config_item')
 
     def test_get_ipv6_address_logs_gettings_ipv6_address_message(self):
-        get_ipv6_address('1.2.3.4', port=2222)
+        get_ipv6_address(host='1.2.3.4', port=2222)
 
         self.assertTrue(self.log.info.called)
 
     def test_get_ipv6_address_gets_ipv6_address(self):
-        get_ipv6_address('1.2.3.4', port=2222)
+        get_ipv6_address(host='1.2.3.4', port=2222)
 
         self.get_cjdns_config_item.assert_called_once_with(
-            'ipv6', '1.2.3.4', port=2222
+            'ipv6', host='1.2.3.4', port=2222
         )
 
     def test_get_ipv6_address_returns_ipv6_address(self):
-        ret = get_ipv6_address('1.2.3.4', port=2222)
+        ret = get_ipv6_address(host='1.2.3.4', port=2222)
 
         self.assertEqual(ret, self.get_cjdns_config_item.return_value)

--- a/tests/unit/raptiformica/shell/cjdns/test_get_public_key.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_get_public_key.py
@@ -5,21 +5,23 @@ from tests.testcase import TestCase
 class TestGetPublicKey(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.shell.cjdns.log')
-        self.get_cjdns_config_item = self.set_up_patch('raptiformica.shell.cjdns.get_cjdns_config_item')
+        self.get_cjdns_config_item = self.set_up_patch(
+            'raptiformica.shell.cjdns.get_cjdns_config_item'
+        )
 
     def test_get_public_key_logs_gettings_public_key_message(self):
-        get_public_key('1.2.3.4', port=2222)
+        get_public_key(host='1.2.3.4', port=2222)
 
         self.assertTrue(self.log.info.called)
 
     def test_get_public_key_gets_public_key(self):
-        get_public_key('1.2.3.4', port=2222)
+        get_public_key(host='1.2.3.4', port=2222)
 
         self.get_cjdns_config_item.assert_called_once_with(
-            'publicKey', '1.2.3.4', port=2222
+            'publicKey', host='1.2.3.4', port=2222
         )
 
     def test_get_public_key_returns_public_key(self):
-        ret = get_public_key('1.2.3.4', port=2222)
+        ret = get_public_key(host='1.2.3.4', port=2222)
 
         self.assertEqual(ret, self.get_cjdns_config_item.return_value)

--- a/tests/unit/raptiformica/shell/compute/test_create_new_compute_type.py
+++ b/tests/unit/raptiformica/shell/compute/test_create_new_compute_type.py
@@ -7,8 +7,8 @@ class CreateNewComputeCheckout(TestCase):
         self.ensure_new_compute_checkout_directory_exists = self.set_up_patch(
             'raptiformica.shell.compute.ensure_new_compute_checkout_directory_exists'
         )
-        self.clone_source_locally = self.set_up_patch(
-            'raptiformica.shell.compute.clone_source_locally'
+        self.clone_source = self.set_up_patch(
+            'raptiformica.shell.compute.clone_source'
         )
         self.path = self.set_up_patch('raptiformica.shell.compute.path')
         self.uuid4 = self.set_up_patch('raptiformica.shell.compute.uuid4')
@@ -31,7 +31,7 @@ class CreateNewComputeCheckout(TestCase):
     def test_create_new_compute_type_directory_clones_source_locally(self):
         create_new_compute_checkout('headless', 'vagrant', "https://github.com/vdloo/vagrantfiles")
 
-        self.clone_source_locally.assert_called_once_with(
+        self.clone_source.assert_called_once_with(
             'https://github.com/vdloo/vagrantfiles',
             self.path.join.return_value
         )

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_installed.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_installed.py
@@ -11,21 +11,29 @@ class TestEnsureConsulInstalled(TestCase):
         self.consul_setup = self.set_up_patch('raptiformica.shell.consul.consul_setup')
 
     def test_ensure_consul_installed_ensure_latest_consul_release(self):
-        ensure_consul_installed('1.2.3.4', port=2222)
+        ensure_consul_installed(host='1.2.3.4', port=2222)
 
-        self.ensure_latest_consul_release.assert_called_once_with('1.2.3.4', port=2222)
+        self.ensure_latest_consul_release.assert_called_once_with(
+            host='1.2.3.4', port=2222
+        )
 
     def test_ensure_consul_installed_ensures_consul_dependencies(self):
-        ensure_consul_installed('1.2.3.4', port=2222)
+        ensure_consul_installed(host='1.2.3.4', port=2222)
 
-        self.ensure_consul_dependencies.assert_called_once_with('1.2.3.4', port=2222)
+        self.ensure_consul_dependencies.assert_called_once_with(
+            host='1.2.3.4', port=2222
+        )
 
     def test_ensure_consul_installed_unzips_consul_release(self):
-        ensure_consul_installed('1.2.3.4', port=2222)
+        ensure_consul_installed(host='1.2.3.4', port=2222)
 
-        self.unzip_consul_release.assert_called_once_with('1.2.3.4', port=2222)
+        self.unzip_consul_release.assert_called_once_with(
+            host='1.2.3.4', port=2222
+        )
 
     def test_ensure_consul_installed_runs_consul_setup(self):
-        ensure_consul_installed('1.2.3.4', port=2222)
+        ensure_consul_installed(host='1.2.3.4', port=2222)
 
-        self.consul_setup.assert_called_once_with('1.2.3.4', port=2222)
+        self.consul_setup.assert_called_once_with(
+            host='1.2.3.4', port=2222
+        )

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_release.py
@@ -12,15 +12,15 @@ class TestUnzipConsulRelease(TestCase):
         )
 
     def test_unzip_consul_release_unzips_consul_binary_on_remote_host(self):
-        unzip_consul_release('1.2.3.4', port=22)
+        unzip_consul_release(host='1.2.3.4', port=22)
 
         self.unzip_consul_binary.assert_called_once_with(
-            '1.2.3.4', port=22
+            host='1.2.3.4', port=22
         )
 
     def test_unzip_consul_release_unzips_consul_web_ui_on_remote_host(self):
-        unzip_consul_release('1.2.3.4', port=22)
+        unzip_consul_release(host='1.2.3.4', port=22)
 
         self.unzip_consul_web_ui.assert_called_once_with(
-            '1.2.3.4', port=22
+            host='1.2.3.4', port=22
         )

--- a/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
@@ -1,4 +1,4 @@
-from raptiformica.shell.git import clone_source_locally
+from raptiformica.shell.git import clone_source
 from tests.testcase import TestCase
 
 
@@ -11,16 +11,16 @@ class TestCloneSourceLocally(TestCase):
         self.process_output = (0, 'standard out output', '')
         self.execute_process.return_value = self.process_output
 
-    def test_clone_source_locally_logs_cloning_source_message(self):
-        clone_source_locally(
+    def test_clone_source_logs_cloning_source_message(self):
+        clone_source(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
         )
 
         self.assertTrue(self.log.info.called)
 
-    def test_clone_source_locally_runs_clone_source_locally(self):
-        clone_source_locally(
+    def test_clone_source_runs_clone_source(self):
+        clone_source(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
         )
@@ -36,10 +36,10 @@ class TestCloneSourceLocally(TestCase):
             shell=False
         )
 
-    def test_clone_source_locally_returns_clone_source_locally_command_exit_code(self):
-        ret = clone_source_locally(
-                'https://github.com/vdloo/puppetfiles',
-                '/usr/etc/puppetfiles',
+    def test_clone_source_returns_clone_source_command_exit_code(self):
+        ret = clone_source(
+            'https://github.com/vdloo/puppetfiles',
+            '/usr/etc/puppetfiles',
         )
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
@@ -1,4 +1,4 @@
-from raptiformica.shell.git import clone_source_remotely
+from raptiformica.shell.git import clone_source
 from tests.testcase import TestCase
 
 
@@ -11,20 +11,20 @@ class TestCloneSourceRemotely(TestCase):
         self.process_output = (0, 'standard out output', '')
         self.execute_process.return_value = self.process_output
 
-    def test_clone_source_remotely_logs_cloning_source_message(self):
-        clone_source_remotely(
+    def test_clone_source_logs_cloning_source_message(self):
+        clone_source(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
-            '127.0.0.1', port=2222
+            host='127.0.0.1', port=2222
         )
 
         self.assertTrue(self.log.info.called)
 
-    def test_clone_source_remotely_runs_clone_source_remotely(self):
-        clone_source_remotely(
+    def test_clone_source_runs_clone_source(self):
+        clone_source(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
-            '127.0.0.1', port=2222
+            host='127.0.0.1', port=2222
         )
 
         expected_command = [
@@ -43,11 +43,11 @@ class TestCloneSourceRemotely(TestCase):
             shell=False
         )
 
-    def test_clone_source_remotely_returns_clone_source_remotely_command_exit_code(self):
-        ret = clone_source_remotely(
+    def test_clone_source_returns_clone_source_command_exit_code(self):
+        ret = clone_source(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
-            '127.0.0.1', port=2222
+            host='127.0.0.1', port=2222
         )
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
@@ -5,8 +5,8 @@ from tests.testcase import TestCase
 class TestEnsureLatestSource(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.shell.git.log')
-        self.run_command_remotely = self.set_up_patch('raptiformica.shell.git.run_command_remotely')
-        self.run_command_remotely.return_value = (0, 'standard out output', None)
+        self.run_command = self.set_up_patch('raptiformica.shell.git.run_command')
+        self.run_command.return_value = (0, 'standard out output', None)
         self.ensure_latest_source_success_factory = self.set_up_patch(
                 'raptiformica.shell.git.ensure_latest_source_success_factory'
         )
@@ -17,52 +17,52 @@ class TestEnsureLatestSource(TestCase):
     def test_ensure_latest_source_logs_ensuring_latest_source_message(self):
         ensure_latest_source(
             "https://github.com/vdloo/puppetfiles",
-            "puppetfiles", '1.2.3.4', port=22
+            "puppetfiles", host='1.2.3.4', port=22
         )
 
         self.assertTrue(self.log.info.called)
 
     def test_ensure_latest_source_creates_ensure_latest_source_success_callback(self):
         ensure_latest_source(
-                "https://github.com/vdloo/puppetfiles",
-                "puppetfiles", '1.2.3.4', port=22
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
         )
 
         self.ensure_latest_source_success_factory.assert_called_once_with(
-                '/usr/etc/puppetfiles',
-                '1.2.3.4', port=22
+            '/usr/etc/puppetfiles',
+            host='1.2.3.4', port=22
         )
 
     def test_ensure_latest_source_creates_ensure_latest_source_failure_callback(self):
         ensure_latest_source(
-                "https://github.com/vdloo/puppetfiles",
-                "puppetfiles", '1.2.3.4', port=22
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
         )
 
         self.ensure_latest_source_failure_factory.assert_called_once_with(
-                "https://github.com/vdloo/puppetfiles",
-                '/usr/etc/puppetfiles',
-                '1.2.3.4', port=22
+            "https://github.com/vdloo/puppetfiles",
+            '/usr/etc/puppetfiles',
+            host='1.2.3.4', port=22
         )
 
     def test_ensure_latest_source_runs_directory_exists_command(self):
         ensure_latest_source(
             "https://github.com/vdloo/puppetfiles",
-            "puppetfiles", '1.2.3.4', port=22,
+            "puppetfiles", host='1.2.3.4', port=22,
         )
 
         expected_command = ['test', '-d', '/usr/etc/puppetfiles']
-        self.run_command_remotely.assert_called_once_with(
+        self.run_command.assert_called_once_with(
             expected_command,
-            '1.2.3.4', port=22,
+            host='1.2.3.4', port=22,
             success_callback=self.ensure_latest_source_success_factory.return_value,
             failure_callback=self.ensure_latest_source_failure_factory.return_value
         )
 
     def test_ensure_latest_source_returns_directory_status_exit_code(self):
         ret = ensure_latest_source(
-                "https://github.com/vdloo/puppetfiles",
-                "puppetfiles", '1.2.3.4', port=22,
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
         )
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source_failure_factory.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source_failure_factory.py
@@ -5,14 +5,14 @@ from tests.testcase import TestCase
 class TestEnsureLatestSourceFailureFactory(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.shell.git.log')
-        self.clone_source_remotely = self.set_up_patch('raptiformica.shell.git.clone_source_remotely')
+        self.clone_source = self.set_up_patch('raptiformica.shell.git.clone_source')
         self.process_output = (1, 'standard out output', 'standard error output')
 
     def test_that_ensure_latest_source_failure_factory_returns_function_that_logs_failure_message(self):
         func = ensure_latest_source_failure_factory(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
-            '1.2.3.4',
+            host='1.2.3.4',
             port=22
         )
         func(self.process_output)
@@ -23,15 +23,15 @@ class TestEnsureLatestSourceFailureFactory(TestCase):
         func = ensure_latest_source_failure_factory(
                 'https://github.com/vdloo/puppetfiles',
                 '/usr/etc/puppetfiles',
-                '1.2.3.4',
+                host='1.2.3.4',
                 port=22
         )
         func(self.process_output)
 
-        self.clone_source_remotely.assert_called_once_with(
+        self.clone_source.assert_called_once_with(
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles',
-            '1.2.3.4',
+            host='1.2.3.4',
             port=22
         )
 

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source_success_factory.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source_success_factory.py
@@ -16,7 +16,11 @@ class TestEnsureLatestSourceSuccessFactory(TestCase):
         self.assertTrue(self.log.info.called)
 
     def test_that_ensure_latest_source_success_factory_returns_function_that_updates_source(self):
-        func = ensure_latest_source_success_factory('/usr/etc/puppetfiles', '1.2.3.4', port=22)
+        func = ensure_latest_source_success_factory(
+            '/usr/etc/puppetfiles', host='1.2.3.4', port=22
+        )
         func(self.process_output)
 
-        self.update_source.assert_called_once_with('/usr/etc/puppetfiles', '1.2.3.4', port=22)
+        self.update_source.assert_called_once_with(
+            '/usr/etc/puppetfiles', host='1.2.3.4', port=22
+        )

--- a/tests/unit/raptiformica/shell/git/test_update_source.py
+++ b/tests/unit/raptiformica/shell/git/test_update_source.py
@@ -19,7 +19,7 @@ class TestUpdateSource(TestCase):
 
         self.pull_origin_master.assert_called_once_with(
             '/usr/etc/puppetfiles',
-            '1.2.3.4',
+            host='1.2.3.4',
             port=22
         )
 
@@ -30,7 +30,7 @@ class TestUpdateSource(TestCase):
 
         self.reset_hard_origin_master.assert_called_once_with(
             '/usr/etc/puppetfiles',
-            '1.2.3.4',
+            host='1.2.3.4',
             port=22
         )
 


### PR DESCRIPTION
- refactor shell/execute.py so that all functions support local or remote hosts by either specifying a host or None
- modeuls/server/deploy.py runs installation functions without host='localhost'