### PR TITLE
upgrade consul to 0.7 for atomic transactions

### DIFF
--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -9,8 +9,8 @@ from raptiformica.shell.wget import wget
 
 log = getLogger(__name__)
 
-CONSUL_RELEASE = 'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip'
-CONSUL_WEB_UI_RELEASE = 'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_web_ui.zip'
+CONSUL_RELEASE = 'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip'
+CONSUL_WEB_UI_RELEASE = 'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip'
 
 
 def ensure_consul_dependencies(host=None, port=22):

--- a/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
@@ -1,6 +1,3 @@
-from os.path import join
-
-from raptiformica.settings import INSTALL_DIR, RAPTIFORMICA_DIR
 from raptiformica.shell.cjdns import cjdns_setup
 from tests.testcase import TestCase
 

--- a/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
@@ -28,7 +28,7 @@ class TestEnsureLatestConsulRelease(TestCase):
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '2222', 'wget', '-nc',
-            'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip'
+            'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip'
         ]
         expected_web_ui_command = [
             '/usr/bin/env', 'ssh',
@@ -37,7 +37,7 @@ class TestEnsureLatestConsulRelease(TestCase):
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '2222', 'wget', '-nc',
-            'https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_web_ui.zip'
+            'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip'
         ]
         expected_calls = [
             call(expected_binary_command, buffered=False, shell=False),

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
@@ -26,7 +26,7 @@ class TestUnzipConsulBinary(TestCase):
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '2222', 'unzip', '-o',
-            'consul_0.6.4_linux_amd64.zip',
+            'consul_0.7.0_linux_amd64.zip',
             '-d', '/usr/bin'
         ]
         self.execute_process.assert_called_once_with(

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
@@ -26,7 +26,7 @@ class TestUnzipConsulWebUI(TestCase):
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
             '-p', '2222', 'unzip', '-o',
-            'consul_0.6.4_web_ui.zip',
+            'consul_0.7.0_web_ui.zip',
             '-d', '/usr/etc/consul_web_ui'
         ]
         self.execute_process.assert_called_once_with(


### PR DESCRIPTION
> Transactional Key/Value API: A new /v1/txn API was added that allows
> for atomic updates to and fetches from multiple entries in the
> key/value store inside of an atomic transaction. This includes
> conditional updates based on obtaining locks, and all other key/value
> store operations.
https://github.com/hashicorp/consul/blob/v0.7.0/CHANGELOG.md
https://github.com/hashicorp/consul/pull/2028