### PR TITLE
types settings use get_config, not .._mapping

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -2,7 +2,7 @@ from os.path import join
 from logging import getLogger
 
 from raptiformica.settings import CJDNS_DEFAULT_PORT, RAPTIFORMICA_DIR, KEY_VALUE_PATH
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory, run_command, check_nonzero_exit
 from raptiformica.shell.hooks import fire_hooks
 from raptiformica.utils import load_json, write_json, ensure_directory, startswith, wait
@@ -91,7 +91,7 @@ def configure_cjdroute_conf():
     """
     log.info("Configuring cjdroute config")
 
-    mapping = get_config()
+    mapping = get_config_mapping()
     cjdns_secret = get_cjdns_password(mapping)
     cjdroute_config = load_json(CJDROUTE_CONF_PATH)
     cjdroute_config['authorizedPasswords'] = [{
@@ -119,7 +119,7 @@ def configure_consul_conf():
                              "export PYTHONPATH=.; " \
                              "./bin/raptiformica_hook.py cluster_change " \
                              "--verbose\"".format(RAPTIFORMICA_DIR)
-    shared_secret = get_consul_password(get_config())
+    shared_secret = get_consul_password(get_config_mapping())
     consul_config = {
         'bootstrap_expect': 3,
         'data_dir': '/opt/consul',
@@ -149,7 +149,7 @@ def count_neighbours():
     Count the amount of peers in the distributed network
     :return:
     """
-    mapping = get_config()
+    mapping = get_config_mapping()
     cjdroute_config = load_json(CJDROUTE_CONF_PATH)
     local_public_key = cjdroute_config['publicKey']
     return len([pk for pk in list_neighbours(mapping) if pk != local_public_key])
@@ -322,7 +322,7 @@ def join_meshnet():
     :return None:
     """
     log.info("Joining the meshnet")
-    mapping = get_config()
+    mapping = get_config_mapping()
     neighbours_path = "{}/meshnet/neighbours/".format(KEY_VALUE_PATH)
     public_keys = list_neighbours(mapping)
     ipv6_addresses = list()

--- a/raptiformica/actions/modules.py
+++ b/raptiformica/actions/modules.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from shutil import rmtree
 
 from raptiformica.settings import USER_MODULES_DIR
-from raptiformica.settings.load import on_disk_mapping, try_delete_config, try_update_config
+from raptiformica.settings.load import on_disk_mapping, try_delete_config, try_update_config_mapping
 from raptiformica.shell.git import clone_source
 
 log = getLogger(__name__)
@@ -52,7 +52,7 @@ def load_configs(module_name):
     module_directory = join(USER_MODULES_DIR, directory)
     mapping = on_disk_mapping(module_dirs=(module_directory,))
     log.debug("Loading keys for {} into the config".format(module_name))
-    try_update_config(mapping)
+    try_update_config_mapping(mapping)
 
 
 def remove_keys(mapping, module_directory):
@@ -89,7 +89,7 @@ def refresh_keys(mapping):
         updated_value = new_mapping.get(key)
         if updated_value:
             mapping_to_update[key] = updated_value
-    try_update_config(mapping_to_update)
+    try_update_config_mapping(mapping_to_update)
 
 
 def unload_module(module_name):

--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -4,7 +4,7 @@ from os.path import join, isdir
 from shutil import rmtree
 
 from raptiformica.settings import EPHEMERAL_DIR, MACHINES_DIR, KEY_VALUE_PATH
-from raptiformica.settings.load import get_config, try_delete_config
+from raptiformica.settings.load import get_config_mapping, try_delete_config
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type, \
     retrieve_compute_type_config_for_server_type, get_compute_types, get_server_types
 from raptiformica.shell.execute import run_command_print_ready_in_directory_factory, log_failure_factory, \
@@ -27,20 +27,11 @@ def retrieve_instance_config_items(items, default='/bin/true', server_type=None,
     log.debug("Retrieving prune instance config")
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
-    mapping = retrieve_compute_type_config_for_server_type(
+    config = retrieve_compute_type_config_for_server_type(
         server_type=server_type,
         compute_type=compute_type
     )
-    return tuple(map(
-        lambda s: s or default,
-        map(
-            lambda item: mapping[next(filter(
-                endswith('/{}'.format(item)),
-                mapping
-            ))],
-            items
-        ))
-    )
+    return tuple([v or default for v in map(lambda k: config[k], items)])
 
 
 def retrieve_prune_instance_config(server_type=None, compute_type=None):
@@ -180,7 +171,7 @@ def ensure_neighbour_removed_from_config(uuid):
     :param str uuid: uuid of the neighbour to remove from the config
     :return None:
     """
-    mapping = get_config()
+    mapping = get_config_mapping()
     # get the matching key for the roots of all
     # neighbours with the specified uuid
     neighbour_keys = map(

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.settings.meshnet import update_meshnet_config
 from raptiformica.settings.types import get_first_server_type
 from raptiformica.shell.config import run_resource_command
@@ -22,7 +22,7 @@ def retrieve_provisioning_configs(server_type=None):
     """
     log.debug("Retrieving provisioning config")
     server_type = server_type or get_first_server_type()
-    mapped = get_config()
+    mapped = get_config_mapping()
 
     server_path = '{}/server/{}'.format(
         KEY_VALUE_PATH, server_type,

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from raptiformica.actions.slave import slave_machine
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type
 from raptiformica.shell.compute import start_instance
 from raptiformica.shell.hooks import fire_hooks
@@ -22,7 +22,7 @@ def retrieve_start_instance_config(server_type=None, compute_type=None):
     log.debug("Retrieving start instance config")
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
-    mapped = get_config()
+    mapped = get_config_mapping()
 
     start_instance_path = '{}/compute/{}/{}/'.format(
         KEY_VALUE_PATH, compute_type, server_type

--- a/raptiformica/distributed/discovery.py
+++ b/raptiformica/distributed/discovery.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.utils import startswith
 
 
@@ -11,7 +11,7 @@ def host_and_port_pairs_from_mutable_config():
     config mapping
     :return iterable[tuple, ..] host_and_port_pairs: A list of tuples containing host and ports
     """
-    mapped = get_config()
+    mapped = get_config_mapping()
     neighbour_kv_path = '{}/meshnet/neighbours/'.format(
         KEY_VALUE_PATH
     )

--- a/raptiformica/settings/hooks.py
+++ b/raptiformica/settings/hooks.py
@@ -1,6 +1,6 @@
 from os.path import join
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.settings.types import get_first_platform_type
 from raptiformica.utils import startswith
 
@@ -13,7 +13,7 @@ def collect_hooks(hook_name, platform_type=None):
     :return iterable[dict, ..]: list of hooks
     """
     platform_type = platform_type or get_first_platform_type()
-    mapped = get_config()
+    mapped = get_config_mapping()
     hook_path = '{}/platform/{}/hooks/{}/'.format(
         KEY_VALUE_PATH, platform_type, hook_name
     )

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -3,7 +3,7 @@ from os.path import join
 from logging import getLogger
 
 from raptiformica.settings import CJDNS_DEFAULT_PORT, KEY_VALUE_PATH
-from raptiformica.settings.load import get_config, try_update_config
+from raptiformica.settings.load import get_config_mapping, try_update_config_mapping
 from raptiformica.shell import cjdns
 
 log = getLogger(__name__)
@@ -16,13 +16,13 @@ def ensure_shared_secret(service):
     :param str service: name of the service to ensure a secret for
     :return dict mapping: the updated config mapping
     """
-    mapping = get_config()
+    mapping = get_config_mapping()
     shared_secret_path = "{}/meshnet/{}/password".format(
         KEY_VALUE_PATH, service
     )
     if not mapping.get(shared_secret_path):
         log.info("Generating new {} secret".format(service))
-        mapping = try_update_config({
+        mapping = try_update_config_mapping({
             shared_secret_path: uuid.uuid4().hex
         })
     return mapping
@@ -76,7 +76,7 @@ def update_neighbours_config(host, port=22, uuid=None):
     neighbour_mapping = {
         join(neighbour_path, k): v for k, v in neighbour_entry.items()
     }
-    return try_update_config(neighbour_mapping)
+    return try_update_config_mapping(neighbour_mapping)
 
 
 def update_meshnet_config(host, port=22, compute_checkout_uuid=None):
@@ -109,4 +109,4 @@ def update_meshnet_config(host, port=22, compute_checkout_uuid=None):
 #     neighbours = {k: v for k, v in config['meshnet']['neighbours'].items()
 #                   if v['uuid'] != uuid}
 #     config['meshnet']['neighbours'] = neighbours
-#     write_config(config, MUTABLE_CONFIG)
+#     write_config_mapping(config, MUTABLE_CONFIG)

--- a/raptiformica/settings/types.py
+++ b/raptiformica/settings/types.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from raptiformica.settings import KEY_VALUE_PATH
 from raptiformica.settings.load import get_config
 from raptiformica.shell.types import check_type_available
-from raptiformica.utils import startswith
 
 log = getLogger(__name__)
 
@@ -12,25 +11,17 @@ log = getLogger(__name__)
 def list_types_from_config(item):
     """
     List types from config.
-    :param str item: name of the type. i.e. 'server_types'
-    :return set types: set of all the types for the item like ['headless, 'workstation']
+    :param str item: name of the type. i.e. 'server'
+    :return dict_keys types: list of all the types for the item like ['headless, 'workstation']
     """
-    mapped = get_config()
-    return set(
-        map(
-            lambda x: x.split('/')[2],
-            filter(
-                startswith('{}/{}/'.format(KEY_VALUE_PATH, item)),
-                mapped
-            )
-        )
-    )
+    config = get_config()
+    return config[KEY_VALUE_PATH][item].keys()
 
 
 def get_available_types_for_item(item):
     """
     Get all available types from a type
-    :param str item: name of the type. i.e. 'server_types'
+    :param str item: name of the type. i.e. 'server'
     :return list types: list of all available types like ['headless, 'workstation']
     """
     return sorted(list(filter(
@@ -106,16 +97,11 @@ def retrieve_compute_type_config_for_server_type(server_type=None, compute_type=
     """
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
-    mapped = get_config()
-    compute_type_config_for_server_type = list(filter(
-        startswith("{}/compute/{}/{}/".format(
-            KEY_VALUE_PATH, compute_type, server_type
-        )),
-        mapped
-    ))
-    if not compute_type_config_for_server_type:
+    config = get_config()
+    try:
+        return config[KEY_VALUE_PATH]['compute'][compute_type][server_type]
+    except KeyError:
         raise RuntimeError(
             "This compute type has no implementation "
             "for server type {}!".format(server_type)
         )
-    return {k: mapped[k] for k in compute_type_config_for_server_type}

--- a/raptiformica/shell/types.py
+++ b/raptiformica/shell/types.py
@@ -1,6 +1,6 @@
 from raptiformica.settings import KEY_VALUE_PATH
 
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from raptiformica.shell.execute import run_command_print_ready
 from raptiformica.utils import startswith, endswith
 
@@ -39,7 +39,7 @@ def check_type_available(item, type_name):
     :param str type_name: name of the type. i.e. 'headless'
     :return bool type_available: True if available, False if not
     """
-    mapped = get_config()
+    mapped = get_config_mapping()
     keys = filter(
         endswith('/available'),
         filter(

--- a/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
@@ -30,7 +30,7 @@ class TestConfigureCjdrouteConf(TestCase):
             },
             'publicKey': 'yet_another_public_key.k'
         }
-        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config')
+        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config_mapping')
         self.get_config.return_value = self.mapping
         self.write_json = self.set_up_patch('raptiformica.actions.mesh.write_json')
 

--- a/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
@@ -23,7 +23,7 @@ class TestConfigureConsulConf(TestCase):
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/ssh_port": "2201",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",
         }
-        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config')
+        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config_mapping')
         self.get_config.return_value = self.mapping
         self.cjdroute_config = {
             'ipv6': 'the_ipv6_address',

--- a/tests/unit/raptiformica/actions/mesh/test_count_neighbours.py
+++ b/tests/unit/raptiformica/actions/mesh/test_count_neighbours.py
@@ -5,7 +5,7 @@ from tests.testcase import TestCase
 class TestCountNeighbours(TestCase):
     def setUp(self):
         self.get_config = self.set_up_patch(
-            'raptiformica.actions.mesh.get_config'
+            'raptiformica.actions.mesh.get_config_mapping'
         )
         self.load_json = self.set_up_patch(
             'raptiformica.actions.mesh.load_json'

--- a/tests/unit/raptiformica/actions/mesh/test_join_meshnet.py
+++ b/tests/unit/raptiformica/actions/mesh/test_join_meshnet.py
@@ -26,7 +26,7 @@ class TestJoinMeshnet(TestCase):
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/ssh_port": "2201",
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",
         }
-        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config')
+        self.get_config = self.set_up_patch('raptiformica.actions.mesh.get_config_mapping')
         self.get_config.return_value = self.mapping
 
     def test_join_meshnet_logs_joining_meshnet_message(self):

--- a/tests/unit/raptiformica/actions/modules/test_load_configs.py
+++ b/tests/unit/raptiformica/actions/modules/test_load_configs.py
@@ -21,7 +21,7 @@ class TestLoadConfigs(TestCase):
             'raptiformica.actions.modules.log'
         )
         self.try_update_config = self.set_up_patch(
-            'raptiformica.actions.modules.try_update_config'
+            'raptiformica.actions.modules.try_update_config_mapping'
         )
 
     def test_load_configs_determines_clone_data_from_module_name(self):

--- a/tests/unit/raptiformica/actions/modules/test_refresh_keys.py
+++ b/tests/unit/raptiformica/actions/modules/test_refresh_keys.py
@@ -19,7 +19,7 @@ class TestRefreshKeys(TestCase):
             return_value=self.new_mapping
         )
         self.try_update_config = self.set_up_patch(
-            'raptiformica.actions.modules.try_update_config'
+            'raptiformica.actions.modules.try_update_config_mapping'
         )
 
     def test_refresh_keys_gets_on_disk_mapping(self):

--- a/tests/unit/raptiformica/actions/prune/test_ensure_neighbour_removed_from_config.py
+++ b/tests/unit/raptiformica/actions/prune/test_ensure_neighbour_removed_from_config.py
@@ -7,7 +7,7 @@ from tests.testcase import TestCase
 class TestEnsureNeighbourRemovedFromConfig(TestCase):
     def setUp(self):
         self.get_config = self.set_up_patch(
-            'raptiformica.actions.prune.get_config'
+            'raptiformica.actions.prune.get_config_mapping'
         )
         self.mapping = {
             "raptiformica/meshnet/cjdns/password": "a_secret",

--- a/tests/unit/raptiformica/actions/prune/test_register_clean_up_triggers.py
+++ b/tests/unit/raptiformica/actions/prune/test_register_clean_up_triggers.py
@@ -23,7 +23,7 @@ class TestRegisterCleanUpTriggers(TestCase):
             "raptiformica/compute/docker/headless/get_port": "echo 22",
             "raptiformica/compute/docker/headless/source": "https://github.com/vdloo/dockerfiles.git",
         }
-        self.get_config = self.set_up_patch('raptiformica.settings.types.get_config')
+        self.get_config = self.set_up_patch('raptiformica.settings.load.get_config_mapping')
         self.get_config.return_value = self.mapping
 
     def test_register_clean_up_triggers_returns_triggers(self):

--- a/tests/unit/raptiformica/actions/prune/test_retrieve_prune_instance_config.py
+++ b/tests/unit/raptiformica/actions/prune/test_retrieve_prune_instance_config.py
@@ -22,8 +22,8 @@ class TestRetrievePruneInstanceConfig(TestCase):
             "raptiformica/compute/vagrant/headless/source": "https://github.com/vdloo/vagrantfiles.git",
             "raptiformica/compute/vagrant/headless/start_instance": "cd headless && vagrant up",
         }
-        self.get_config = self.set_up_patch('raptiformica.settings.types.get_config')
-        self.get_config.return_value = self.mapping
+        self.get_config_mapping = self.set_up_patch('raptiformica.settings.load.get_config_mapping')
+        self.get_config_mapping.return_value = self.mapping
 
     def test_retrieve_prune_instance_config_logs_retrieving_instance_config_message(self):
         retrieve_prune_instance_config(server_type='headless', compute_type='docker')
@@ -36,7 +36,7 @@ class TestRetrievePruneInstanceConfig(TestCase):
 
     def test_retrieve_prune_instance_config_returns_prune_instance_config_for_server_type(self):
         detect_stale_instance_command, clean_up_instance_command = retrieve_prune_instance_config(
-                server_type='headless', compute_type='docker'
+            server_type='headless', compute_type='docker'
         )
 
         self.assertEqual(

--- a/tests/unit/raptiformica/actions/slave/test_retrieve_provisioning_configs.py
+++ b/tests/unit/raptiformica/actions/slave/test_retrieve_provisioning_configs.py
@@ -12,7 +12,7 @@ class TestRetrieveProvisioningConfigs(TestCase):
         )
         self.get_first_server_type.return_value = 'workstation'
         self.get_config = self.set_up_patch(
-            'raptiformica.actions.slave.get_config'
+            'raptiformica.actions.slave.get_config_mapping'
         )
         self.mapping = {
             "raptiformica/compute/vagrant/headless/get_port": "cd headless && vagrant ssh-config | grep Port | awk '{print $NF}'",

--- a/tests/unit/raptiformica/actions/spawn/test_retrieve_start_instance_config.py
+++ b/tests/unit/raptiformica/actions/spawn/test_retrieve_start_instance_config.py
@@ -6,7 +6,7 @@ class TestRetrieveStartInstanceConfig(TestCase):
     def setUp(self):
         self.types_log = self.set_up_patch('raptiformica.settings.types.log')
         self.spawn_log = self.set_up_patch('raptiformica.actions.spawn.log')
-        self.get_config = self.set_up_patch('raptiformica.actions.spawn.get_config')
+        self.get_config_mapping = self.set_up_patch('raptiformica.actions.spawn.get_config_mapping')
         self.mapping = {
             "raptiformica/compute/docker/headless/available": "docker -v",
             "raptiformica/compute/docker/headless/clean_up_instance_command": "bash -c 'cd ubuntu64 && [ -f container_id ] && cat container_id | xargs sudo docker rm -f || /bin/true'",
@@ -26,7 +26,7 @@ class TestRetrieveStartInstanceConfig(TestCase):
             "raptiformica/server/headless/name": "puppetfiles",
             "raptiformica/server/headless/source": "https://github.com/vdloo/puppetfiles.git"
         }
-        self.get_config.return_value = self.mapping
+        self.get_config_mapping.return_value = self.mapping
 
     def test_retrieve_start_instance_config_logs_retrieving_instance_config_message(self):
         retrieve_start_instance_config(server_type='headless', compute_type='vagrant')

--- a/tests/unit/raptiformica/distributed/discovery/test_host_and_port_pairs_from_mutable_config.py
+++ b/tests/unit/raptiformica/distributed/discovery/test_host_and_port_pairs_from_mutable_config.py
@@ -5,7 +5,7 @@ from tests.testcase import TestCase
 class TestHostAndPortPairsFromMutableConfig(TestCase):
     def setUp(self):
         self.get_config = self.set_up_patch(
-            'raptiformica.distributed.discovery.get_config'
+            'raptiformica.distributed.discovery.get_config_mapping'
         )
         self.mapping = {
             "raptiformica/meshnet/neighbours/public_key_1.k/cjdns_ipv6_address": "1:2:3:4",

--- a/tests/unit/raptiformica/settings/load/test_cache_config.py
+++ b/tests/unit/raptiformica/settings/load/test_cache_config.py
@@ -1,5 +1,5 @@
 from raptiformica.settings import MUTABLE_CONFIG
-from raptiformica.settings.load import cache_config
+from raptiformica.settings.load import cache_config_mapping
 from tests.testcase import TestCase
 
 
@@ -10,15 +10,15 @@ class TestCacheConfig(TestCase):
             'some/other/key1': 'some_other_value1'
         }
         self.write_config = self.set_up_patch(
-            'raptiformica.settings.load.write_config'
+            'raptiformica.settings.load.write_config_mapping'
         )
 
     def test_cache_config_raises_error_if_empty_mapping(self):
         with self.assertRaises(RuntimeError):
-            cache_config({})
+            cache_config_mapping({})
 
     def test_cache_config_writes_mapping_to_mutable_config(self):
-        cache_config(self.mapping)
+        cache_config_mapping(self.mapping)
 
         self.write_config.assert_called_once_with(
             self.mapping,

--- a/tests/unit/raptiformica/settings/load/test_cached_config.py
+++ b/tests/unit/raptiformica/settings/load/test_cached_config.py
@@ -1,5 +1,5 @@
 from raptiformica.settings import MUTABLE_CONFIG
-from raptiformica.settings.load import cached_config
+from raptiformica.settings.load import cached_config_mapping
 from tests.testcase import TestCase
 
 
@@ -10,12 +10,12 @@ class TestCachedConfig(TestCase):
         )
 
     def test_cached_config_loads_mutable_config_as_json(self):
-        cached_config()
+        cached_config_mapping()
 
         self.load_json.assert_called_once_with(MUTABLE_CONFIG)
 
     def test_cached_config_returns_parsed_mutable_config_as_json(self):
-        ret = cached_config()
+        ret = cached_config_mapping()
 
         self.assertEqual(self.load_json.return_value, ret)
 

--- a/tests/unit/raptiformica/settings/load/test_download_config.py
+++ b/tests/unit/raptiformica/settings/load/test_download_config.py
@@ -1,5 +1,5 @@
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import download_config
+from raptiformica.settings.load import download_config_mapping
 from tests.testcase import TestCase
 
 
@@ -9,18 +9,18 @@ class TestDownloadConfig(TestCase):
         self.get_mapping = self.set_up_patch('raptiformica.settings.load.consul_conn.get_mapping')
 
     def test_download_config_logs_debug_message(self):
-        download_config()
+        download_config_mapping()
 
         self.assertTrue(self.log.debug.called)
 
     def test_download_config_gets_root_kv_mapping(self):
-        download_config()
+        download_config_mapping()
 
         self.get_mapping.assert_called_once_with(
             KEY_VALUE_PATH
         )
 
     def test_download_config_returns_mapping(self):
-        ret = download_config()
+        ret = download_config_mapping()
 
         self.assertEqual(self.get_mapping.return_value, ret)

--- a/tests/unit/raptiformica/settings/load/test_get_config.py
+++ b/tests/unit/raptiformica/settings/load/test_get_config.py
@@ -1,6 +1,6 @@
 from urllib.error import URLError
 
-from raptiformica.settings.load import get_config
+from raptiformica.settings.load import get_config_mapping
 from tests.testcase import TestCase
 
 
@@ -13,36 +13,36 @@ class TestGetConfig(TestCase):
             'raptiformica.settings.load.log'
         )
         self.get_local_config = self.set_up_patch(
-            'raptiformica.settings.load.get_local_config'
+            'raptiformica.settings.load.get_local_config_mapping'
         )
 
     def test_get_config_syncs_shared_config_mapping(self):
-        get_config()
+        get_config_mapping()
 
         self.sync_shared_config_mapping.assert_called_once_with()
 
     def test_get_config_returns_synced_shared_config_mapping(self):
-        ret = get_config()
+        ret = get_config_mapping()
 
         self.assertEqual(self.sync_shared_config_mapping.return_value, ret)
 
     def test_get_config_logs_debug_message_if_the_shared_config_can_not_be_retrieved(self):
         self.sync_shared_config_mapping.side_effect = URLError('reason')
 
-        get_config()
+        get_config_mapping()
 
         self.assertTrue(self.log.debug.called)
 
     def test_get_config_gets_local_config_if_the_shared_config_can_not_be_retrieved(self):
         self.sync_shared_config_mapping.side_effect = URLError('reason')
 
-        get_config()
+        get_config_mapping()
 
         self.get_local_config.assert_called_once_with()
 
     def test_get_config_returns_local_config_if_the_shared_config_can_not_be_retrieved(self):
         self.sync_shared_config_mapping.side_effect = URLError('reason')
 
-        ret = get_config()
+        ret = get_config_mapping()
 
         self.assertEqual(self.get_local_config.return_value, ret)

--- a/tests/unit/raptiformica/settings/load/test_get_local_config.py
+++ b/tests/unit/raptiformica/settings/load/test_get_local_config.py
@@ -1,11 +1,11 @@
-from raptiformica.settings.load import get_local_config
+from raptiformica.settings.load import get_local_config_mapping
 from tests.testcase import TestCase
 
 
 class TestGetLocalConfig(TestCase):
     def setUp(self):
         self.cached_config = self.set_up_patch(
-            'raptiformica.settings.load.cached_config'
+            'raptiformica.settings.load.cached_config_mapping'
         )
         self.log = self.set_up_patch('raptiformica.settings.load.log')
         self.on_disk_mapping = self.set_up_patch(
@@ -13,32 +13,32 @@ class TestGetLocalConfig(TestCase):
         )
 
     def test_get_local_config_gets_cached_config(self):
-        get_local_config()
+        get_local_config_mapping()
 
         self.cached_config.assert_called_once_with()
 
     def test_get_local_config_returns_cached_config(self):
-        ret = get_local_config()
+        ret = get_local_config_mapping()
 
         self.assertEqual(self.cached_config.return_value, ret)
 
     def test_get_local_config_logs_debug_message_if_cache_not_found(self):
         self.cached_config.side_effect = FileNotFoundError
 
-        get_local_config()
+        get_local_config_mapping()
 
         self.assertTrue(self.log.debug.called)
 
     def test_get_local_config_gets_on_disk_mapping_if_cache_not_found(self):
         self.cached_config.side_effect = FileNotFoundError
 
-        get_local_config()
+        get_local_config_mapping()
 
         self.on_disk_mapping.assert_called_once_with()
 
     def test_get_local_config_returns_on_disk_mapping_if_cache_not_found(self):
         self.cached_config.side_effect = FileNotFoundError
 
-        ret = get_local_config()
+        ret = get_local_config_mapping()
 
         self.assertEqual(self.on_disk_mapping.return_value, ret)

--- a/tests/unit/raptiformica/settings/load/test_sync_shared_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_sync_shared_config_mapping.py
@@ -8,16 +8,16 @@ from tests.testcase import TestCase
 class TestSyncSharedConfigMapping(TestCase):
     def setUp(self):
         self.download_config = self.set_up_patch(
-            'raptiformica.settings.load.download_config'
+            'raptiformica.settings.load.download_config_mapping'
         )
         self.get_local_config = self.set_up_patch(
-            'raptiformica.settings.load.get_local_config'
+            'raptiformica.settings.load.get_local_config_mapping'
         )
         self.update_config = self.set_up_patch(
-            'raptiformica.settings.load.update_config'
+            'raptiformica.settings.load.update_config_mapping'
         )
         self.cache_config = self.set_up_patch(
-            'raptiformica.settings.load.cache_config'
+            'raptiformica.settings.load.cache_config_mapping'
         )
 
     def test_sync_shared_config_mapping_downloads_config(self):

--- a/tests/unit/raptiformica/settings/load/test_try_delete_config.py
+++ b/tests/unit/raptiformica/settings/load/test_try_delete_config.py
@@ -26,12 +26,12 @@ class TestTryDeleteConfig(TestCase):
             "raptiformica/meshnet/neighbours/a_different_pubkey.k/uuid": "eb442c6170694b12b277c9e88d714cf1",
         }
         self.get_config = self.set_up_patch(
-            'raptiformica.settings.load.get_config',
+            'raptiformica.settings.load.get_config_mapping',
             return_value=self.mapping
         )
         self.get_config.return_value = self.mapping
         self.cache_config = self.set_up_patch(
-            'raptiformica.settings.load.cache_config'
+            'raptiformica.settings.load.cache_config_mapping'
         )
         self.sync_shared_config_mapping = self.set_up_patch(
             'raptiformica.settings.load.sync_shared_config_mapping'

--- a/tests/unit/raptiformica/settings/load/test_try_update_config.py
+++ b/tests/unit/raptiformica/settings/load/test_try_update_config.py
@@ -2,7 +2,7 @@ from urllib.error import URLError, HTTPError
 
 from mock import Mock
 
-from raptiformica.settings.load import try_update_config
+from raptiformica.settings.load import try_update_config_mapping
 from tests.testcase import TestCase
 
 
@@ -13,17 +13,17 @@ class TestTryUpdateConfig(TestCase):
             'some/other/key': 'other_value'
         }
         self.update_config = self.set_up_patch(
-            'raptiformica.settings.load.update_config'
+            'raptiformica.settings.load.update_config_mapping'
         )
         self.get_config = self.set_up_patch(
-            'raptiformica.settings.load.get_config'
+            'raptiformica.settings.load.get_config_mapping'
         )
         self.cache_config = self.set_up_patch(
-            'raptiformica.settings.load.cache_config'
+            'raptiformica.settings.load.cache_config_mapping'
         )
 
     def test_try_update_config_updates_config_with_mapping(self):
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.update_config.assert_called_once_with(
             self.mapping
@@ -32,28 +32,28 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_gets_config_if_http_error(self):
         self.update_config.side_effect = HTTPError('url', 'code', 'msg', 'hdrs', Mock())
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.assert_called_once_with()
 
     def test_try_update_config_gets_config_if_url_error(self):
         self.update_config.side_effect = URLError('reason')
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.assert_called_once_with()
 
     def test_try_update_config_gets_config_if_connection_refused_error(self):
         self.update_config.side_effect = ConnectionRefusedError
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.assert_called_once_with()
 
     def test_try_update_config_updates_cached_mapping_if_http_error(self):
         self.update_config.side_effect = HTTPError('url', 'code', 'msg', 'hdrs', Mock())
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.return_value.update.assert_called_once_with(
             self.mapping
@@ -62,7 +62,7 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_updates_cached_mapping_if_url_error(self):
         self.update_config.side_effect = URLError('reason')
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.return_value.update.assert_called_once_with(
                 self.mapping
@@ -71,7 +71,7 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_updates_cached_mapping_if_connection_refused_error(self):
         self.update_config.side_effect = ConnectionRefusedError
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.get_config.return_value.update.assert_called_once_with(
                 self.mapping
@@ -80,7 +80,7 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_caches_updated_mapping_if_http_error(self):
         self.update_config.side_effect = HTTPError('url', 'code', 'msg', 'hdrs', Mock())
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.cache_config.assert_called_once_with(
             self.get_config.return_value
@@ -89,7 +89,7 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_caches_updated_mapping_if_url_error(self):
         self.update_config.side_effect = URLError('reason')
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.cache_config.assert_called_once_with(
             self.get_config.return_value
@@ -98,34 +98,34 @@ class TestTryUpdateConfig(TestCase):
     def test_try_update_config_caches_updated_mapping_if_connection_refused_error(self):
         self.update_config.side_effect = ConnectionRefusedError
 
-        try_update_config(self.mapping)
+        try_update_config_mapping(self.mapping)
 
         self.cache_config.assert_called_once_with(
             self.get_config.return_value
         )
 
     def test_try_update_config_returns_mapping(self):
-        ret = try_update_config(self.mapping)
+        ret = try_update_config_mapping(self.mapping)
 
         self.assertEqual(self.update_config.return_value, ret)
 
     def test_try_update_config_returns_cached_mapping_if_http_error(self):
         self.update_config.side_effect = HTTPError('url', 'code', 'msg', 'hdrs', Mock())
 
-        ret = try_update_config(self.mapping)
+        ret = try_update_config_mapping(self.mapping)
 
         self.assertEqual(self.get_config.return_value, ret)
 
     def test_try_update_config_returns_cached_mapping_if_url_error(self):
         self.update_config.side_effect = URLError('reason')
 
-        ret = try_update_config(self.mapping)
+        ret = try_update_config_mapping(self.mapping)
 
         self.assertEqual(self.get_config.return_value, ret)
 
     def test_try_update_config_returns_cached_mapping_if_connection_refused_error(self):
         self.update_config.side_effect = ConnectionRefusedError
 
-        ret = try_update_config(self.mapping)
+        ret = try_update_config_mapping(self.mapping)
 
         self.assertEqual(self.get_config.return_value, ret)

--- a/tests/unit/raptiformica/settings/load/test_update_config.py
+++ b/tests/unit/raptiformica/settings/load/test_update_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings.load import update_config
+from raptiformica.settings.load import update_config_mapping
 from tests.testcase import TestCase
 
 
@@ -9,24 +9,24 @@ class TestUpdateConfig(TestCase):
             'some/other/key': 'some_other_value'
         }
         self.upload_config = self.set_up_patch(
-            'raptiformica.settings.load.upload_config'
+            'raptiformica.settings.load.upload_config_mapping'
         )
         self.download_config = self.set_up_patch(
-            'raptiformica.settings.load.download_config'
+            'raptiformica.settings.load.download_config_mapping'
         )
 
     def test_update_config_uploads_mapping(self):
-        update_config(self.mapping)
+        update_config_mapping(self.mapping)
 
         self.upload_config.assert_called_once_with(self.mapping)
 
     def test_update_config_downloads_config(self):
-        update_config(self.mapping)
+        update_config_mapping(self.mapping)
 
         self.download_config.assert_called_once_with()
 
     def test_update_config_returns_updated_config(self):
-        ret = update_config(self.mapping)
+        ret = update_config_mapping(self.mapping)
 
         self.assertEqual(
             ret, self.download_config.return_value

--- a/tests/unit/raptiformica/settings/load/test_upload_config.py
+++ b/tests/unit/raptiformica/settings/load/test_upload_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings.load import upload_config
+from raptiformica.settings.load import upload_config_mapping
 from tests.testcase import TestCase
 
 
@@ -12,11 +12,11 @@ class TestUploadConfig(TestCase):
         self.put_mapping = self.set_up_patch('raptiformica.settings.load.consul_conn.put_mapping')
 
     def test_upload_config_logs_debug_message(self):
-        upload_config(self.mapping)
+        upload_config_mapping(self.mapping)
 
         self.assertTrue(self.log.debug.called)
 
     def test_upload_config_puts_mapping(self):
-        upload_config(self.mapping)
+        upload_config_mapping(self.mapping)
 
         self.put_mapping.assert_called_once_with(self.mapping)

--- a/tests/unit/raptiformica/settings/load/test_write_config.py
+++ b/tests/unit/raptiformica/settings/load/test_write_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings.load import write_config
+from raptiformica.settings.load import write_config_mapping
 from tests.testcase import TestCase
 
 
@@ -10,7 +10,7 @@ class TestWriteConfig(TestCase):
         }
 
     def test_write_config_writes_json(self):
-        write_config(self.data, 'a_config_file.json')
+        write_config_mapping(self.data, 'a_config_file.json')
 
         self.write_json.assert_called_once_with(
             self.data,

--- a/tests/unit/raptiformica/settings/meshnet/test_ensure_shared_secret.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_ensure_shared_secret.py
@@ -7,9 +7,9 @@ class TestEnsureSharedSecret(TestCase):
         self.uuid = self.set_up_patch('raptiformica.settings.meshnet.uuid')
         self.uuid.uuid4.return_value.hex = 'a_generated_shared_secret'
         self.try_update_config = self.set_up_patch(
-            'raptiformica.settings.meshnet.try_update_config'
+            'raptiformica.settings.meshnet.try_update_config_mapping'
         )
-        self.get_config = self.set_up_patch('raptiformica.settings.meshnet.get_config')
+        self.get_config = self.set_up_patch('raptiformica.settings.meshnet.get_config_mapping')
         self.get_config.return_value = {
             'raptiformica/meshnet/consul/password': 'a_secret'
         }

--- a/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
@@ -9,7 +9,7 @@ class TestUpdateNeighboursConfig(TestCase):
         self.cjdns.get_ipv6_address.return_value = 'ipv6_address'
         self.config = {'meshnet': {'neighbours': {}}}
         self.try_update_config = self.set_up_patch(
-            'raptiformica.settings.meshnet.try_update_config'
+            'raptiformica.settings.meshnet.try_update_config_mapping'
         )
 
     def test_update_neighbours_config_gets_cjdns_public_key_from_remote_host(self):

--- a/tests/unit/raptiformica/settings/types/test_list_types_from_config.py
+++ b/tests/unit/raptiformica/settings/types/test_list_types_from_config.py
@@ -1,0 +1,33 @@
+from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings.types import list_types_from_config
+from tests.testcase import TestCase
+
+
+class TestListTypesFromConfig(TestCase):
+    def setUp(self):
+        self.get_config = self.set_up_patch(
+            'raptiformica.settings.types.get_config'
+        )
+        self.get_config.return_value = {
+            KEY_VALUE_PATH: {
+                'server': {
+                    'headless': {},
+                    'workstation': {}
+                }
+            }
+        }
+
+    def test_list_types_from_config_gets_config(self):
+        list_types_from_config('server')
+
+        self.get_config.assert_called_once_with()
+
+    def test_list_types_from_config_lists_types_from_config(self):
+        ret = list_types_from_config('server')
+
+        self.assertCountEqual(ret, ['headless', 'workstation'])
+
+    def test_list_types_from_config_raises_keyerror_if_type_is_not_configured(self):
+        with self.assertRaises(KeyError):
+            list_types_from_config('compute')
+

--- a/tests/unit/raptiformica/settings/types/test_retrieve_compute_type_config_for_server_type.py
+++ b/tests/unit/raptiformica/settings/types/test_retrieve_compute_type_config_for_server_type.py
@@ -1,0 +1,69 @@
+from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings.types import retrieve_compute_type_config_for_server_type
+from tests.testcase import TestCase
+
+
+class TestRetrieveComputeTypeConfigForServerType(TestCase):
+    def setUp(self):
+        self.get_first_server_type = self.set_up_patch(
+            'raptiformica.settings.types.get_first_server_type'
+        )
+        self.get_first_server_type.return_value = 'workstation'
+        self.get_first_compute_type = self.set_up_patch(
+            'raptiformica.settings.types.get_first_compute_type'
+        )
+        self.get_first_compute_type.return_value = 'vagrant'
+        self.get_config = self.set_up_patch(
+            'raptiformica.settings.types.get_config'
+        )
+        self.get_config.return_value = {
+            KEY_VALUE_PATH: {
+                'compute': {
+                    'vagrant': {
+                        'workstation': {
+                            'these_are': 'some_settings'
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_retrieve_compute_type_config_for_server_type_gets_first_server_type(self):
+        retrieve_compute_type_config_for_server_type()
+
+        self.get_first_server_type.assert_called_once_with()
+
+    def test_retrieve_compute_type_config_for_server_type_gets_first_compute_type(self):
+        retrieve_compute_type_config_for_server_type()
+
+        self.get_first_compute_type.assert_called_once_with()
+
+    def test_retrieve_compute_type_config_for_server_type_does_not_get_first_server_type_if_one_is_specified(self):
+        retrieve_compute_type_config_for_server_type(server_type='workstation')
+
+        self.assertFalse(self.get_first_server_type.called)
+
+    def test_retrieve_compute_type_config_for_server_type_does_not_get_first_compute_type_if_one_is_specified(self):
+        retrieve_compute_type_config_for_server_type(compute_type='vagrant')
+
+        self.assertFalse(self.get_first_compute_type.called)
+
+    def test_retrieve_compute_type_config_for_server_type_gets_config(self):
+        retrieve_compute_type_config_for_server_type()
+
+        self.get_config.assert_called_once_with()
+
+    def test_retrieve_compute_type_config_for_server_type_returns_config_for_server_type(self):
+        ret = retrieve_compute_type_config_for_server_type(
+            server_type='workstation', compute_type='vagrant'
+        )
+
+        self.assertEqual(ret, {'these_are': 'some_settings'})
+
+    def test_retrieve_compute_type_config_for_server_type_raises_runtime_error_when_no_such_compute_type(self):
+        with self.assertRaises(RuntimeError):
+            retrieve_compute_type_config_for_server_type(compute_type='does_not_exist')
+
+    def test_retrieve_compute_type_config_for_server_type_raises_runtime_error_when_no_such_server_type(self):
+        with self.assertRaises(RuntimeError):
+            retrieve_compute_type_config_for_server_type(server_type='does_not_exist')


### PR DESCRIPTION
Use get_config instead of get_config_mapping. No need to filter the
mapping by keys anymore now it is always translated back to a dict.