### PR TITLE
cache cloned repositories

### DIFF
--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -172,7 +172,8 @@ def get_neighbours_by_uuid(uuid):
     Should only be one, but in case there are more those should also be dealt with.
     """
     config = get_config()
-    neighbours = config[KEY_VALUE_PATH]['meshnet'].get('neighbours', {})
+    meshnet_config = config[KEY_VALUE_PATH].get('meshnet', {})
+    neighbours = meshnet_config.get('neighbours', {})
     return [
         '{}/meshnet/neighbours/{}/'.format(KEY_VALUE_PATH, k)
         for k, v in neighbours.items() if v['uuid'] == uuid

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -1,15 +1,14 @@
 from logging import getLogger
 
 from raptiformica.settings import KEY_VALUE_PATH
-from raptiformica.settings.load import get_config_mapping, get_config
+from raptiformica.settings.load import get_config
 from raptiformica.settings.meshnet import update_meshnet_config
 from raptiformica.settings.types import get_first_server_type
 from raptiformica.shell.config import run_resource_command
-from raptiformica.shell.git import ensure_latest_source
+from raptiformica.shell.git import ensure_latest_source_from_artifacts
 from raptiformica.shell.hooks import fire_hooks
 from raptiformica.shell.raptiformica import mesh
 from raptiformica.shell.rsync import upload_self, download_artifacts
-from raptiformica.utils import endswith, startswith
 
 log = getLogger(__name__)
 
@@ -45,7 +44,9 @@ def provision_machine(host=None, port=22, server_type=None):
     provisioning_configs = retrieve_provisioning_configs(server_type)
     for name, config in provisioning_configs.items():
         log.info("Provisioning for {}".format(name))
-        ensure_latest_source(config['source'], name, host=host, port=port)
+        ensure_latest_source_from_artifacts(
+            config['source'], name, host=host, port=port
+        )
         run_resource_command(config['bootstrap'], name, host=host, port=port)
 
 

--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from functools import reduce
+from http.client import HTTPException
 from itertools import chain
 from os.path import join
 from os import remove
@@ -80,7 +81,7 @@ def try_config_request(func):
     try:
         log.debug("Attempting API call on local Consul instance")
         return func()
-    except (HTTPError, URLError, ConnectionRefusedError, ConnectionResetError):
+    except (HTTPError, HTTPException, URLError, ConnectionRefusedError, ConnectionResetError):
         log.debug("Attempting API call on remote Consul instance")
         with suppress(RuntimeError):
             with forward_any_port(source_port=8500, predicate=['consul', 'members']):
@@ -134,7 +135,7 @@ def try_update_config_mapping(mapping):
     """
     try:
         mapping = update_config_mapping(mapping)
-    except (HTTPError, URLError, ConnectionRefusedError, ConnectionResetError):
+    except (HTTPError, HTTPException, URLError, ConnectionRefusedError, ConnectionResetError):
         cached_mapping = get_config_mapping()
         cached_mapping.update(mapping)
         cache_config_mapping(cached_mapping)

--- a/raptiformica/shell/cjdns.py
+++ b/raptiformica/shell/cjdns.py
@@ -6,7 +6,7 @@ from raptiformica.settings import INSTALL_DIR, RAPTIFORMICA_DIR
 from raptiformica.shell.execute import raise_failure_factory, \
     run_critical_unbuffered_command_print_ready, run_command_print_ready, \
     run_multiple_labeled_commands
-from raptiformica.shell.git import ensure_latest_source
+from raptiformica.shell.git import ensure_latest_source_from_artifacts
 
 CJDNS_REPOSITORY = "https://github.com/cjdelisle/cjdns.git"
 
@@ -123,6 +123,8 @@ def ensure_cjdns_installed(host=None, port=22):
     :return None:
     """
     log.info("Ensuring CJDNS is installed")
-    ensure_latest_source(CJDNS_REPOSITORY, "cjdns", host=host, port=port)
+    ensure_latest_source_from_artifacts(
+        CJDNS_REPOSITORY, "cjdns", host=host, port=port
+    )
     ensure_cjdns_dependencies(host=host, port=port)
     cjdns_setup(host=host, port=port)

--- a/raptiformica/shell/execute.py
+++ b/raptiformica/shell/execute.py
@@ -134,6 +134,7 @@ def run_command_remotely(command, host, port=22,
     :return tuple process_output (exit code, standard out, standard error):
     """
     ssh_command_as_list = ['/usr/bin/env', 'ssh',
+                           '-o', 'ConnectTimeout=5',
                            '-o', 'StrictHostKeyChecking=no',
                            '-o', 'UserKnownHostsFile=/dev/null',
                            '-o', 'PasswordAuthentication=no',

--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -20,7 +20,7 @@ def download(source, destination, host, port=22):
     :return bool status: success or failure
     """
     download_command = [
-        '/usr/bin/env', 'rsync', '-q', '-L', '-avz',
+        '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz',
         'root@{}:{}'.format(host, source), destination,
         '--exclude=.venv', '--exclude=*.pyc',
         '-e', 'ssh -p {} '
@@ -50,7 +50,7 @@ def upload(source, destination, host, port=22):
     :return bool status: success or failure
     """
     upload_command = [
-        '/usr/bin/env', 'rsync', '-q', '-L', '-avz',
+        '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz',
         source, 'root@{}:{}'.format(host, destination),
         '--exclude=.venv', '--exclude=*.pyc',
         '--exclude=var',

--- a/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
+++ b/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
@@ -69,3 +69,12 @@ class TestGetNeighboursByUuid(TestCase):
         ret = get_neighbours_by_uuid('eb442c6170694b12b277c9e88d714cf2')
 
         self.assertCountEqual(ret, tuple())
+
+    def test_get_neighbours_by_uuid_returns_empty_iterable_if_no_meshnet_config(self):
+        self.get_config.return_value = {
+            KEY_VALUE_PATH: {}
+        }
+
+        ret = get_neighbours_by_uuid('eb442c6170694b12b277c9e88d714cf2')
+
+        self.assertCountEqual(ret, tuple())

--- a/tests/unit/raptiformica/actions/slave/test_provision_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_provision_machine.py
@@ -20,8 +20,8 @@ class TestProvision(TestCase):
                 'bootstrap': './deploy.sh'
             },
         }
-        self.ensure_latest_source = self.set_up_patch(
-            'raptiformica.actions.slave.ensure_latest_source'
+        self.ensure_latest_source_from_artifacts = self.set_up_patch(
+            'raptiformica.actions.slave.ensure_latest_source_from_artifacts'
         )
         self.run_resource_command = self.set_up_patch(
             'raptiformica.actions.slave.run_resource_command'
@@ -72,7 +72,7 @@ class TestProvision(TestCase):
             ),
         )
         self.assertCountEqual(
-            self.ensure_latest_source.mock_calls, expected_calls
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
         )
 
     def test_provision_runs_configured_bootstrap_command_for_all_provisioning_configs_on_the_remote_machine(self):

--- a/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
+++ b/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
@@ -43,18 +43,21 @@ class TestTryMachineCommand(TestCase):
         try_machine_command(self.host_and_port_pairs, self.command)
 
         expected_command_as_list1 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'ConnectTimeout=5',
                                      '-o', 'StrictHostKeyChecking=no',
                                      '-o', 'UserKnownHostsFile=/dev/null',
                                      '-o', 'PasswordAuthentication=no',
                                      'root@1.2.3.4',
                                      '-p', '2222', '/bin/true']
         expected_command_as_list2 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'ConnectTimeout=5',
                                      '-o', 'StrictHostKeyChecking=no',
                                      '-o', 'UserKnownHostsFile=/dev/null',
                                      '-o', 'PasswordAuthentication=no',
                                      'root@5.6.7.8',
                                      '-p', '22', '/bin/true']
         expected_command_as_list3 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'ConnectTimeout=5',
                                      '-o', 'StrictHostKeyChecking=no',
                                      '-o', 'UserKnownHostsFile=/dev/null',
                                      '-o', 'PasswordAuthentication=no',
@@ -77,12 +80,14 @@ class TestTryMachineCommand(TestCase):
         try_machine_command(self.host_and_port_pairs, self.command, attempt_limit=2)
 
         expected_command_as_list1 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'ConnectTimeout=5',
                                      '-o', 'StrictHostKeyChecking=no',
                                      '-o', 'UserKnownHostsFile=/dev/null',
                                      '-o', 'PasswordAuthentication=no',
                                      'root@1.2.3.4',
                                      '-p', '2222', '/bin/true']
         expected_command_as_list2 = ['/usr/bin/env', 'ssh',
+                                     '-o', 'ConnectTimeout=5',
                                      '-o', 'StrictHostKeyChecking=no',
                                      '-o', 'UserKnownHostsFile=/dev/null',
                                      '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
@@ -20,6 +20,7 @@ class TestCjdnsSetup(TestCase):
         cjdns_setup('1.2.3.4', port=2222)
 
         expected_command = "/usr/bin/env ssh " \
+                           "-o ConnectTimeout=5 " \
                            "-o StrictHostKeyChecking=no " \
                            "-o UserKnownHostsFile=/dev/null " \
                            "-o PasswordAuthentication=no " \

--- a/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
@@ -18,6 +18,7 @@ class TestEnsureCjdnsDependencies(TestCase):
 
         expected_archlinux_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '
@@ -30,6 +31,7 @@ class TestEnsureCjdnsDependencies(TestCase):
         )
         expected_debian_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '

--- a/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_installed.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_installed.py
@@ -5,7 +5,9 @@ from tests.testcase import TestCase
 class TestEnsureCjdnsInstalled(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.shell.cjdns.log')
-        self.ensure_latest_source = self.set_up_patch('raptiformica.shell.cjdns.ensure_latest_source')
+        self.ensure_latest_source_from_artifacts = self.set_up_patch(
+            'raptiformica.shell.cjdns.ensure_latest_source_from_artifacts'
+        )
         self.ensure_cjdns_dependencies = self.set_up_patch('raptiformica.shell.cjdns.ensure_cjdns_dependencies')
         self.cjdns_setup = self.set_up_patch('raptiformica.shell.cjdns.cjdns_setup')
 
@@ -17,7 +19,7 @@ class TestEnsureCjdnsInstalled(TestCase):
     def test_ensure_cjdns_installed_ensures_latest_source(self):
         ensure_cjdns_installed(host='1.2.3.4', port=2222)
 
-        self.ensure_latest_source.assert_called_once_with(
+        self.ensure_latest_source_from_artifacts.assert_called_once_with(
             CJDNS_REPOSITORY,
             "cjdns",
             host='1.2.3.4',

--- a/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
@@ -15,6 +15,7 @@ class TestGetCjdnsConfigItem(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
@@ -35,6 +36,7 @@ class TestGetCjdnsConfigItem(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/config/test_run_resource_command.py
+++ b/tests/unit/raptiformica/shell/config/test_run_resource_command.py
@@ -21,6 +21,7 @@ class TestRunResourceCommand(TestCase):
         run_resource_command(self.resource_command, 'puppetfiles', '1.2.3.4', port=2222)
 
         expected_remote_command = "/usr/bin/env ssh " \
+                                  "-o ConnectTimeout=5 " \
                                   "-o StrictHostKeyChecking=no " \
                                   "-o UserKnownHostsFile=/dev/null " \
                                   "-o PasswordAuthentication=no " \

--- a/tests/unit/raptiformica/shell/consul/test_consul_setup.py
+++ b/tests/unit/raptiformica/shell/consul/test_consul_setup.py
@@ -24,6 +24,7 @@ class TestConsulSetup(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
@@ -18,6 +18,7 @@ class TestEnsureConsulDependencies(TestCase):
 
         expected_archlinux_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '
@@ -30,6 +31,7 @@ class TestEnsureConsulDependencies(TestCase):
         )
         expected_debian_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '

--- a/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
@@ -23,6 +23,7 @@ class TestEnsureLatestConsulRelease(TestCase):
 
         expected_binary_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
@@ -32,6 +33,7 @@ class TestEnsureLatestConsulRelease(TestCase):
         ]
         expected_web_ui_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
@@ -21,6 +21,7 @@ class TestUnzipConsulBinary(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
@@ -21,6 +21,7 @@ class TestUnzipConsulWebUI(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
@@ -26,7 +26,7 @@ class TestCloneSourceLocally(TestCase):
         )
 
         expected_command = [
-            '/usr/bin/env', 'git', 'clone',
+            '/usr/bin/env', 'git', 'clone', '--recursive',
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles'
         ]

--- a/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
@@ -29,11 +29,12 @@ class TestCloneSourceRemotely(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
             'root@127.0.0.1', '-p', '2222',
-            '/usr/bin/env', 'git', 'clone',
+            '/usr/bin/env', 'git', 'clone', '--recursive',
             'https://github.com/vdloo/puppetfiles',
             '/usr/etc/puppetfiles'
         ]

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
@@ -1,3 +1,6 @@
+from os.path import join
+
+from raptiformica.settings import INSTALL_DIR
 from raptiformica.shell.git import ensure_latest_source
 from tests.testcase import TestCase
 
@@ -8,10 +11,10 @@ class TestEnsureLatestSource(TestCase):
         self.run_command = self.set_up_patch('raptiformica.shell.git.run_command')
         self.run_command.return_value = (0, 'standard out output', None)
         self.ensure_latest_source_success_factory = self.set_up_patch(
-                'raptiformica.shell.git.ensure_latest_source_success_factory'
+            'raptiformica.shell.git.ensure_latest_source_success_factory'
         )
         self.ensure_latest_source_failure_factory = self.set_up_patch(
-                'raptiformica.shell.git.ensure_latest_source_failure_factory'
+            'raptiformica.shell.git.ensure_latest_source_failure_factory'
         )
 
     def test_ensure_latest_source_logs_ensuring_latest_source_message(self):
@@ -66,3 +69,47 @@ class TestEnsureLatestSource(TestCase):
         )
 
         self.assertEqual(ret, 0)
+
+    def test_ensure_latest_source_creates_success_callback_with_default_provisioning_directory(self):
+        ensure_latest_source(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        self.ensure_latest_source_success_factory.assert_called_once_with(
+            join(INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
+        )
+
+    def test_ensure_latest_source_creates_failure_callback_with_default_provisioning_directory(self):
+        ensure_latest_source(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        self.ensure_latest_source_failure_factory.assert_called_once_with(
+            "https://github.com/vdloo/puppetfiles",
+            join(INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
+        )
+
+    def test_ensure_latest_source_creates_success_callback_with_specified_provisioning_directory(self):
+        ensure_latest_source(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            destination='/tmp/some/directory'
+        )
+
+        self.ensure_latest_source_success_factory.assert_called_once_with(
+            '/tmp/some/directory/puppetfiles', host='1.2.3.4', port=22
+        )
+
+    def test_ensure_latest_source_creates_failure_callback_with_specified_provisioning_directory(self):
+        ensure_latest_source(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            destination='/tmp/some/directory'
+        )
+
+        self.ensure_latest_source_failure_factory.assert_called_once_with(
+            "https://github.com/vdloo/puppetfiles",
+            '/tmp/some/directory/puppetfiles', host='1.2.3.4', port=22
+        )

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
@@ -1,0 +1,77 @@
+from mock import call, Mock
+
+from raptiformica.settings import INSTALL_DIR
+from raptiformica.shell.git import ensure_latest_source_from_artifacts
+from tests.testcase import TestCase
+
+
+class TestEnsureLatestSourceFromArtifacts(TestCase):
+    def setUp(self):
+        self.ensure_directory = self.set_up_patch(
+            'raptiformica.shell.git.ensure_directory'
+        )
+        self.ensure_latest_source = self.set_up_patch(
+            'raptiformica.shell.git.ensure_latest_source'
+        )
+
+    def test_ensure_latest_source_from_artifacts_ensures_artifacts_directory(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        self.ensure_directory.assert_called_once_with(
+            '.raptiformica.d/artifacts/repositories'
+        )
+
+    def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_install_dir(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        expected_calls = (
+            call(
+                "https://github.com/vdloo/puppetfiles",
+                "puppetfiles", host='1.2.3.4', port=22,
+                destination='.raptiformica.d/artifacts/repositories'
+            ),
+            call(
+                "file:///root/.raptiformica.d/artifacts/repositories/puppetfiles",
+                "puppetfiles", host='1.2.3.4', port=22,
+                destination=INSTALL_DIR
+            )
+        )
+        self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)
+
+    def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_specified_dir(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            destination='/tmp/some/other/directory'
+        )
+
+        expected_calls = (
+            call(
+                "https://github.com/vdloo/puppetfiles",
+                "puppetfiles", host='1.2.3.4', port=22,
+                destination='.raptiformica.d/artifacts/repositories'
+            ),
+            call(
+                "file:///root/.raptiformica.d/artifacts/repositories/puppetfiles",
+                "puppetfiles", host='1.2.3.4', port=22,
+                destination='/tmp/some/other/directory'
+            )
+        )
+        self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)
+
+    def test_ensure_latest_source_from_artifacts_returns_cached_ensure_result(self):
+        expected_result = Mock()
+        self.ensure_latest_source.side_effect = [Mock(), expected_result]
+
+        ret = ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        self.assertEqual(ret, expected_result)

--- a/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
+++ b/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
@@ -20,6 +20,7 @@ class TestPullOriginMaster(TestCase):
         pull_origin_master('/usr/etc/puppetfiles', '1.2.3.4', port=22)
 
         expected_command = "/usr/bin/env ssh " \
+                           "-o ConnectTimeout=5 " \
                            "-o StrictHostKeyChecking=no " \
                            "-o UserKnownHostsFile=/dev/null " \
                            "-o PasswordAuthentication=no " \

--- a/tests/unit/raptiformica/shell/git/test_reset_hard_origin_master.py
+++ b/tests/unit/raptiformica/shell/git/test_reset_hard_origin_master.py
@@ -20,6 +20,7 @@ class TestResetHardOriginMaster(TestCase):
         reset_hard_origin_master('/usr/etc/puppetfiles', '1.2.3.4', port=22)
 
         expected_command = "/usr/bin/env ssh " \
+                           "-o ConnectTimeout=5 " \
                            "-o StrictHostKeyChecking=no " \
                            "-o UserKnownHostsFile=/dev/null " \
                            "-o PasswordAuthentication=no " \

--- a/tests/unit/raptiformica/shell/package_manager/test_update_package_manager_cache.py
+++ b/tests/unit/raptiformica/shell/package_manager/test_update_package_manager_cache.py
@@ -18,6 +18,7 @@ class TestUpdatePackageManagerCache(TestCase):
 
         expected_archlinux_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '
@@ -30,6 +31,7 @@ class TestUpdatePackageManagerCache(TestCase):
         )
         expected_debian_call = call(
             '/usr/bin/env ssh '
+            '-o ConnectTimeout=5 '
             '-o StrictHostKeyChecking=no '
             '-o UserKnownHostsFile=/dev/null '
             '-o PasswordAuthentication=no '

--- a/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
@@ -21,6 +21,7 @@ class TestCreateRemoteRaptiformicaCache(TestCase):
 
         expected_upload_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
@@ -27,6 +27,7 @@ class TestRunRaptiformicaCommand(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/rsync/test_download.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download.py
@@ -15,7 +15,7 @@ class TestDownload(TestCase):
         download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
 
         expected_download_command = [
-            '/usr/bin/env', 'rsync', '-q', '-L', '-avz',
+            '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz',
             'root@1.2.3.4:{}'.format(PROJECT_DIR),
             INSTALL_DIR, '--exclude=.venv',
             '--exclude=*.pyc', '-e', 'ssh -p 22 '

--- a/tests/unit/raptiformica/shell/rsync/test_upload.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload.py
@@ -15,7 +15,7 @@ class TestUpload(TestCase):
         upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
 
         expected_upload_command = [
-            '/usr/bin/env', 'rsync', '-q', '-L', '-avz', PROJECT_DIR,
+            '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz', PROJECT_DIR,
             'root@1.2.3.4:{}'.format(INSTALL_DIR), '--exclude=.venv',
             '--exclude=*.pyc', '--exclude=var', '-e',
             'ssh -p 22 '

--- a/tests/unit/raptiformica/shell/unzip/test_unzip.py
+++ b/tests/unit/raptiformica/shell/unzip/test_unzip.py
@@ -19,6 +19,7 @@ class TestUnzip(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',

--- a/tests/unit/raptiformica/shell/wget/test_wget.py
+++ b/tests/unit/raptiformica/shell/wget/test_wget.py
@@ -19,6 +19,7 @@ class TestWget(TestCase):
 
         expected_command = [
             '/usr/bin/env', 'ssh',
+            '-o', 'ConnectTimeout=5',
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',


### PR DESCRIPTION
in the .raptiformica.d/artifacts directory so that the system can still
operate if the resources can not be reached but have been downloaded (or
inherited) by the bootstrapping peer once before.