### PR TITLE
default provisioner runs in home dir

### DIFF
--- a/modules/server/default.json
+++ b/modules/server/default.json
@@ -4,7 +4,7 @@
     "headless": {
       "raptiformica_default_provisioner": {
         "source": "file:///usr/etc/raptiformica",
-        "bootstrap": "export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; ./modules/server/deploy.py"
+        "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py"
       }
     }
   }

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
@@ -31,9 +31,9 @@ class TestUnzipConsulWebUI(TestCase):
             '-d', '/usr/etc/consul_web_ui'
         ]
         self.execute_process.assert_called_once_with(
-                expected_command,
-                buffered=False,
-                shell=False
+            expected_command,
+            buffered=False,
+            shell=False
         )
 
     def test_unzip_consul_web_ui_raises_error_when_ensuring_latest_web_ui_files_fails(self):


### PR DESCRIPTION
so the used repositories can be properly cached