### PR TITLE
check compute type available before spawning

### DIFF
--- a/modules/platform/consensus.json
+++ b/modules/platform/consensus.json
@@ -6,11 +6,11 @@
         "after_mesh": {
           "ensure_second_node": {
             "predicate": "[ $(/usr/bin/consul members | grep alive | wc -l) -lt 3 ]",
-            "command": "cat /dev/zero | ssh-keygen -q -N '' > /dev/null 2>&1; eval $(ssh-agent -s); ssh-add; export PYTHONPATH=.; ./bin/raptiformica_spawn.py --verbose"
+            "command": "export PYTHONPATH=.; ./bin/raptiformica_spawn --check-available && ([ ! -f $HOME/.ssh/id_rsa ] && cat /dev/zero | ssh-keygen -q -N '' > /dev/null 2>&1; eval $(ssh-agent -s); ssh-add; ./bin/raptiformica_spawn.py --verbose)"
           },
           "ensure_third_node": {
             "predicate": "[ $(/usr/bin/consul members | grep alive | wc -l) -lt 3 ]",
-            "command": "cat /dev/zero | ssh-keygen -q -N '' > /dev/null 2>&1; eval $(ssh-agent -s); ssh-add; export PYTHONPATH=.; ./bin/raptiformica_spawn.py --verbose"
+            "command": "export PYTHONPATH=.; ./bin/raptiformica_spawn --check-available && ([ ! -f $HOME/.ssh/id_rsa ] && cat /dev/zero | ssh-keygen -q -N '' > /dev/null 2>&1; eval $(ssh-agent -s); ssh-add; ./bin/raptiformica_spawn.py --verbose)"
           }
         },
         "cluster_change": {

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -65,29 +65,33 @@ def start_compute_type(server_type=None, compute_type=None):
     )
 
 
-def spawn_machine(provision=False, assimilate=False, server_type=None, compute_type=None):
+def spawn_machine(provision=False, assimilate=False, server_type=None, compute_type=None, check_available=False):
     """
     Start a new instance, provision it and join it into the distributed network
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
     :param str server_type: name of the server type to provision the machine as
     :param str compute_type: name of the compute type to start an instance on
+    :param bool check_available: Don't really spawn a machine, just check if this host could
     :return None:
     """
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
-    log.info("Spawning machine of server type {} with compute type {}".format(
-        server_type, compute_type
-    ))
-    verify_ssh_agent_running()
-    uuid, host, port = start_compute_type(
-        server_type=server_type, compute_type=compute_type
-    )
-    fire_hooks('after_start_instance')
-    slave_machine(
-        host, port=port,
-        assimilate=assimilate,
-        provision=provision,
-        server_type=server_type,
-        uuid=uuid
-    )
+    # If we are just checking for availability we are done here
+    if not check_available:
+        log.info(
+            "Spawning machine of server type {} with compute "
+            "type {}".format(server_type, compute_type)
+        )
+        verify_ssh_agent_running()
+        uuid, host, port = start_compute_type(
+            server_type=server_type, compute_type=compute_type
+        )
+        fire_hooks('after_start_instance')
+        slave_machine(
+            host, port=port,
+            assimilate=assimilate,
+            provision=provision,
+            server_type=server_type,
+            uuid=uuid
+        )

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -115,6 +115,8 @@ def parse_spawn_arguments():
     parser.add_argument('--compute-type', type=str, default=get_first_compute_type(),
                         choices=get_compute_types(),
                         help='Specify a compute type. Default is {}'.format(get_first_compute_type()))
+    parser.add_argument('--check-available', action='store_true',
+                        help="Check if there is a configured server and compute type available on this host")
     return parse_arguments(parser)
 
 
@@ -129,6 +131,7 @@ def spawn():
         provision=not args.no_provision,
         server_type=args.server_type,
         compute_type=args.compute_type,
+        check_available=args.check_available
     )
 
 

--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -15,6 +15,7 @@ MODULES_DIR = join(PROJECT_DIR, 'modules')
 USER_MODULES_DIR = join(ABS_CACHE_DIR, 'modules')
 USER_ARTIFACTS_DIR = join(ABS_CACHE_DIR, 'artifacts')
 KEY_VALUE_ENDPOINT = 'http://localhost:8500/v1/kv'
+KEY_VALUE_TIMEOUT = 3  # How long to wait for a config retrieval
 KEY_VALUE_PATH = 'raptiformica'
 
 CJDNS_DEFAULT_PORT = 4863

--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -14,16 +14,19 @@ from consul_kv.utils import dict_merge
 from raptiformica.distributed.proxy import forward_any_port
 
 from raptiformica.settings import MODULES_DIR, ABS_CACHE_DIR, KEY_VALUE_ENDPOINT, \
-    KEY_VALUE_PATH, USER_MODULES_DIR, MUTABLE_CONFIG, USER_ARTIFACTS_DIR
+    KEY_VALUE_PATH, USER_MODULES_DIR, MUTABLE_CONFIG, USER_ARTIFACTS_DIR, KEY_VALUE_TIMEOUT
 from raptiformica.utils import load_json, write_json, list_all_files_with_extension_in_directory, ensure_directory
 
 log = getLogger(__name__)
 
-consul_conn = Connection(endpoint=KEY_VALUE_ENDPOINT)
+consul_conn = Connection(
+    endpoint=KEY_VALUE_ENDPOINT,
+    timeout=KEY_VALUE_TIMEOUT
+)
 
 API_EXCEPTIONS = (HTTPError, HTTPException, URLError,
                   ConnectionRefusedError, ConnectionResetError,
-                  BadStatusLine)
+                  BadStatusLine, OSError)
 
 
 def write_config_mapping(config, config_file):
@@ -285,7 +288,7 @@ def get_config_mapping():
                                 "to get the latest state from the cache now."
     try:
         return sync_shared_config_mapping()
-    except URLError:
+    except API_EXCEPTIONS:
         log.debug(failed_distributed_config)
         return get_local_config_mapping()
 

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -37,9 +37,6 @@ class TestSpawnMachine(TestCase):
             compute_type=self.get_first_compute_type.return_value
         )
 
-    def test_spawn_machine_does_not_slave_or_assimilate_machine_by_default(self):
-        spawn_machine(provision=True)
-
     def test_spawn_machine_slaves_machine_as_default_server_type(self):
         spawn_machine(provision=True)
 
@@ -77,4 +74,11 @@ class TestSpawnMachine(TestCase):
             server_type='workstation',
             uuid='some_uuid_1234'
         )
+
+    def test_spawn_machine_does_not_actually_spawn_a_machine_if_check_available_specified(self):
+        spawn_machine(server_type='workstation', compute_type='docker', check_available=True)
+
+        self.assertFalse(self.start_compute_type.called)
+        self.assertFalse(self.slave_machine.called)
+        self.assertFalse(self.fire_hooks.called)
 

--- a/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
@@ -53,6 +53,8 @@ class TestParseSpawnArguments(TestCase):
                  choices=self.get_compute_types.return_value,
                  help='Specify a compute type. Default is {}'.format(
                          self.get_first_compute_type.return_value)),
+            call('--check-available', action='store_true',
+                 help='Check if there is a configured server and compute type available on this host')
         ]
         self.assertEqual(
             self.argument_parser.return_value.add_argument.mock_calls,

--- a/tests/unit/raptiformica/cli/test_spawn.py
+++ b/tests/unit/raptiformica/cli/test_spawn.py
@@ -9,7 +9,8 @@ class TestSpawn(TestCase):
         self.parse_spawn_arguments = self.set_up_patch('raptiformica.cli.parse_spawn_arguments')
         self.parse_spawn_arguments.return_value = Mock(
             no_provision=False, no_assimilate=False,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
         self.spawn_machine = self.set_up_patch('raptiformica.cli.spawn_machine')
 
@@ -23,32 +24,51 @@ class TestSpawn(TestCase):
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
 
     def test_spawn_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
         self.parse_spawn_arguments.return_value = Mock(
             no_provision=False, no_assimilate=True,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
 
         spawn()
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=False,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
 
-    def test_spawn_dose_not_provsion_machine_when_no_provision_is_passed(self):
+    def test_spawn_dose_not_provision_machine_when_no_provision_is_passed(self):
         self.parse_spawn_arguments.return_value = Mock(
             no_provision=True, no_assimilate=False,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
 
         spawn()
 
         self.spawn_machine.assert_called_once_with(
             provision=False, assimilate=True,
-            server_type='headless', compute_type='vagrant'
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
 
+    def test_spawn_only_checks_available_if_specified(self):
+        self.parse_spawn_arguments.return_value = Mock(
+            no_provision=False, no_assimilate=False,
+            server_type='headless', compute_type='vagrant',
+            check_available=True
+        )
+
+        spawn()
+
+        self.spawn_machine.assert_called_once_with(
+            provision=True, assimilate=True,
+            server_type='headless', compute_type='vagrant',
+            check_available=True
+        )


### PR DESCRIPTION
so hosts that can't spawn any new instances anyway won't block on
generating new temporary keys when no entropy is available.

- test available before spawning instances on spawned hosts
- Consul KV connection config retrieval timeout is 3 seconds

todo: in the future run haveged as part of the provisioning