### PR TITLE
tweak consul settings for fast moving devices

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -131,6 +131,21 @@ def configure_consul_conf():
         'advertise_addr': cjdroute_config['ipv6'],
         'encrypt': shared_secret,
         'disable_remote_exec': False,
+        'performance': {
+            # High performance settings. Machines leave and join the
+            # cluster fast and often.
+            'raft_multiplier': 1
+        },
+        'dns_config': {
+            'allow_stale': True,
+            "recursor_timeout": '1s'
+        },
+        "leave_on_terminate": True,
+        "skip_leave_on_interrupt": False,
+        "reconnect_timeout": "8h",  # The value must be >= 8 hours.
+        "reconnect_timeout_wan": "8h",
+        "translate_wan_addrs": False,
+        "rejoin_after_leave": True,
         'watches': [
             {
                 'type': 'service',

--- a/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
@@ -66,6 +66,21 @@ class TestConfigureConsulConf(TestCase):
             'advertise_addr': 'the_ipv6_address',
             'encrypt': 'a_different_secret',
             'disable_remote_exec': False,
+            'performance': {
+                # High performance settings. Machines leave
+                # and join the cluster fast and often.
+                'raft_multiplier': 1
+            },
+            'dns_config': {
+                'allow_stale': True,
+                "recursor_timeout": '1s'
+            },
+            "leave_on_terminate": True,
+            "skip_leave_on_interrupt": False,
+            "reconnect_timeout": "8h",  # The value must be >= 8 hours.
+            "reconnect_timeout_wan": "8h",
+            "translate_wan_addrs": False,
+            "rejoin_after_leave": True,
             'watches': [
                 {
                     'type': 'service',


### PR DESCRIPTION
Machines should be able to leave and join the cluster very often.
Consistency is less important than discovery in this case.