### PR TITLE
rename check_available to only_check_available

### DIFF
--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -65,20 +65,20 @@ def start_compute_type(server_type=None, compute_type=None):
     )
 
 
-def spawn_machine(provision=False, assimilate=False, server_type=None, compute_type=None, check_available=False):
+def spawn_machine(provision=False, assimilate=False, server_type=None, compute_type=None, only_check_available=False):
     """
     Start a new instance, provision it and join it into the distributed network
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
     :param str server_type: name of the server type to provision the machine as
     :param str compute_type: name of the compute type to start an instance on
-    :param bool check_available: Don't really spawn a machine, just check if this host could
+    :param bool only_check_available: Don't really spawn a machine, just check if this host could
     :return None:
     """
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
     # If we are just checking for availability we are done here
-    if not check_available:
+    if not only_check_available:
         log.info(
             "Spawning machine of server type {} with compute "
             "type {}".format(server_type, compute_type)

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -131,7 +131,7 @@ def spawn():
         provision=not args.no_provision,
         server_type=args.server_type,
         compute_type=args.compute_type,
-        check_available=args.check_available
+        only_check_available=args.check_available
     )
 
 

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -75,8 +75,8 @@ class TestSpawnMachine(TestCase):
             uuid='some_uuid_1234'
         )
 
-    def test_spawn_machine_does_not_actually_spawn_a_machine_if_check_available_specified(self):
-        spawn_machine(server_type='workstation', compute_type='docker', check_available=True)
+    def test_spawn_machine_does_not_actually_spawn_a_machine_if_only_check_available_specified(self):
+        spawn_machine(server_type='workstation', compute_type='docker', only_check_available=True)
 
         self.assertFalse(self.start_compute_type.called)
         self.assertFalse(self.slave_machine.called)

--- a/tests/unit/raptiformica/cli/test_spawn.py
+++ b/tests/unit/raptiformica/cli/test_spawn.py
@@ -25,7 +25,7 @@ class TestSpawn(TestCase):
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True,
             server_type='headless', compute_type='vagrant',
-            check_available=False
+            only_check_available=False
         )
 
     def test_spawn_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
@@ -40,7 +40,7 @@ class TestSpawn(TestCase):
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=False,
             server_type='headless', compute_type='vagrant',
-            check_available=False
+            only_check_available=False
         )
 
     def test_spawn_dose_not_provision_machine_when_no_provision_is_passed(self):
@@ -55,7 +55,7 @@ class TestSpawn(TestCase):
         self.spawn_machine.assert_called_once_with(
             provision=False, assimilate=True,
             server_type='headless', compute_type='vagrant',
-            check_available=False
+            only_check_available=False
         )
 
     def test_spawn_only_checks_available_if_specified(self):
@@ -70,5 +70,5 @@ class TestSpawn(TestCase):
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True,
             server_type='headless', compute_type='vagrant',
-            check_available=True
+            only_check_available=True
         )


### PR DESCRIPTION
to make it clearer that this flag does a dry run instead of the actual thing