### PR TITLE
add package entrypoint

### DIFF
--- a/bin/raptiformica
+++ b/bin/raptiformica
@@ -2,6 +2,7 @@
 export PYTHONPATH=../
 
 SPAWN_ENTRYPOINT="raptiformica_spawn.py"
+PACKAGE_ENTRYPOINT="raptiformica_package.py"
 PRUNE_ENTRYPOINT="raptiformica_prune.py"
 DESTROY_ENTRYPOINT="raptiformica_destroy.py"
 MEMBERS_ENTRYPOINT="raptiformica_members.py"
@@ -21,6 +22,9 @@ Usage: raptiformica [CMD..] [OPTIONS] [-h]
 
   slave                      Provision and join a machine 
                              into the network
+
+  package                    Package a machine into a
+                             reusable image
 
   update                     Update the local machine by
                              running the configured commands
@@ -88,6 +92,10 @@ case $1 in
     ;;
     hook)
     RAPTIFORMICA_CMD=$HOOK_ENTRYPOINT
+    shift
+    ;;
+    package)
+    RAPTIFORMICA_CMD=$PACKAGE_ENTRYPOINT
     shift
     ;;
     *)

--- a/bin/raptiformica_package.py
+++ b/bin/raptiformica_package.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+from raptiformica.cli import package
+
+if __name__ == '__main__':
+    package()
+else:
+    raise RuntimeError("This script is an entry point and can not be imported")

--- a/modules/compute/vagrant/Vagrantfile
+++ b/modules/compute/vagrant/Vagrantfile
@@ -16,10 +16,16 @@ PACKAGED_CATALOG = File.join(PACKAGED_DIR, 'images/catalog.json')
 BASE_BOX_URL = 'http://cloud.terry.im/vagrant/archlinux-x86_64.box'
 BOX_URL = File.exists?(PACKAGED_CATALOG) ? PACKAGED_CATALOG : BASE_BOX_URL
 
-# remove external virtualbox-guest-dkms in Archlinux boxes before running vagrant-vbguest
-require_relative 'inline/remove-guest-dkms.rb'
+if ! File.exists?(PACKAGED_CATALOG)
+    # remove external virtualbox-guest-dkms in Archlinux boxes before running vagrant-vbguest
+    require_relative 'inline/remove-guest-dkms.rb'
+end
 
 Vagrant.configure('2') do |config|
+    if File.exists?(PACKAGED_CATALOG)
+        config.vbguest.auto_update = false
+	config.vm.synced_folder '.', '/vagrant', disabled: true
+    end
     config.tun.enabled = true
     config.ssh.forward_agent = true
     VAGRANT_SCRIPT_DIR = File.dirname(__FILE__) << '/'

--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -3,8 +3,8 @@
 echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer = http://ftp.snt.utwente.nl/pub/os/linux/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
 pacman -Sy --noconfirm
-pacman -S ruby git puppet --noconfirm
-pacman -S acl --noconfirm
+pacman -S ruby git puppet --noconfirm --needed
+pacman -S acl --noconfirm --needed
 
 # Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
 # yet again before docker will work inside the virtualized guest due to the right veth kernel module 

--- a/modules/compute/vagrant/provision.sh
+++ b/modules/compute/vagrant/provision.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-userdel terry	# remove image maintainer's user
+userdel terry --force || /bin/true  # remove image maintainer's user
 puppet module install puppetlabs-vcsrepo
 puppet module install maestrodev-wget
 puppet module install saz-sudo

--- a/modules/compute/vagrant/raptiformica.json
+++ b/modules/compute/vagrant/raptiformica.json
@@ -9,7 +9,8 @@
         "get_hostname": "cd modules/compute/vagrant && vagrant ssh -c 'ip addr show' 2>&1 | grep 'inet ' | tail -n 1 | awk '{print$2}' | cut -d '/' -f1",
         "get_port": "echo 22",
         "detect_stale_instance": "cd modules/compute/vagrant && vagrant status | grep running",
-        "clean_up_instance_command": "cd modules/compute/vagrant && vagrant destroy -f"
+        "clean_up_instance_command": "cd modules/compute/vagrant && vagrant destroy -f",
+        "package": "cd modules/compute/vagrant && ./package.sh"
       }
     }
   }

--- a/raptiformica/actions/package.py
+++ b/raptiformica/actions/package.py
@@ -1,0 +1,50 @@
+from logging import getLogger
+
+from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings.load import get_config
+from raptiformica.settings.types import get_first_server_type, get_first_compute_type
+from raptiformica.shell.execute import run_command
+
+log = getLogger(__name__)
+
+
+def retrieve_package_machine_config(server_type=None, compute_type=None):
+    """
+    Get the package command from the server_type as defined in the compute_type
+    :param str compute_type: name of the compute type to start an instance on
+    :param str server_type: name of the server type to provision the machine as
+    :return str package_command: The package command
+    """
+    server_type = server_type or get_first_server_type()
+    compute_type = compute_type or get_first_compute_type()
+    config = get_config()
+    server_config = config[KEY_VALUE_PATH][
+        'compute'
+    ][compute_type].get(server_type, {})
+    if 'package' not in server_config:
+        raise RuntimeError("No packaging command specified for "
+                           "server type {} of compute type {}"
+                           "".format(server_type, compute_type))
+    return server_config['package']
+
+
+def package_machine(server_type=None, compute_type=None, only_check_available=False):
+    """
+    Package a machine into a reusable image for the compute provider
+    :param str server_type: name of the server type to provision the machine as
+    :param str compute_type: name of the compute type to start an instance on
+    :param bool only_check_available: Don't really spawn a machine, just check if this host could
+    :return:
+    """
+    server_type = server_type or get_first_server_type()
+    compute_type = compute_type or get_first_compute_type()
+    # If we are just checking for availability we are done here
+    if not only_check_available:
+        log.info(
+            "Packaging machine of server type {} with compute "
+            "type {}".format(server_type, compute_type)
+        )
+        package_command = retrieve_package_machine_config(
+            server_type=server_type, compute_type=compute_type
+        )
+        run_command(package_command, buffered=False, shell=True)

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -4,6 +4,7 @@ from raptiformica.actions.hook import trigger_handlers
 from raptiformica.actions.members import rejoin_members, show_members
 from raptiformica.actions.mesh import mesh_machine
 from raptiformica.actions.modules import load_module, unload_module
+from raptiformica.actions.package import package_machine
 from raptiformica.actions.prune import prune_local_machines
 from raptiformica.actions.slave import slave_machine
 from raptiformica.actions.destroy import destroy_cluster
@@ -129,6 +130,42 @@ def spawn():
     spawn_machine(
         assimilate=not args.no_assimilate,
         provision=not args.no_provision,
+        server_type=args.server_type,
+        compute_type=args.compute_type,
+        only_check_available=args.check_available
+    )
+
+
+def parse_package_arguments():
+    """
+    Parse the commandline options for packaging a compute type
+    :return obj args: parsed arguments
+    """
+    parser = ArgumentParser(
+        prog="raptiformica package",
+        description='Package a compute type into a reusable image to speed up '
+                    'booting instances'
+    )
+    parser.add_argument('--server-type', type=str, default=get_first_server_type(),
+                        choices=get_server_types(),
+                        help='Specify a server type. Default is {}'.format(get_first_server_type()))
+    parser.add_argument('--compute-type', type=str, default=get_first_compute_type(),
+                        choices=get_compute_types(),
+                        help='Specify a compute type. Default is {}'.format(get_first_compute_type()))
+    parser.add_argument('--check-available', action='store_true',
+                        help="Check if there is a configured server and compute type available on this host")
+    return parse_arguments(parser)
+
+
+def package():
+    """
+    Package a machine into a reusable image
+    :return None:
+    """
+    args = parse_package_arguments()
+    # todo: perform the booting and destroying in
+    # raptiformica, not the compute module
+    package_machine(
         server_type=args.server_type,
         compute_type=args.compute_type,
         only_check_available=args.check_available

--- a/tests/unit/raptiformica/actions/package/test_package_machine.py
+++ b/tests/unit/raptiformica/actions/package/test_package_machine.py
@@ -1,0 +1,67 @@
+from raptiformica.actions.package import package_machine
+from tests.testcase import TestCase
+
+
+class TestPackageMachine(TestCase):
+    def setUp(self):
+        self.get_first_server_type = self.set_up_patch(
+            'raptiformica.actions.package.get_first_server_type'
+        )
+        self.get_first_server_type.return_value = 'headless'
+        self.get_first_compute_type = self.set_up_patch(
+            'raptiformica.actions.package.get_first_compute_type'
+        )
+        self.get_first_compute_type.return_value = 'vagrant'
+        self.retrieve_package_machine_config = self.set_up_patch(
+            'raptiformica.actions.package.retrieve_package_machine_config'
+        )
+        self.run_command = self.set_up_patch(
+            'raptiformica.actions.package.run_command'
+        )
+
+    def test_package_machine_gets_first_server_type_if_no_server_type_specified(self):
+        package_machine()
+
+        self.get_first_server_type.assert_called_once_with()
+
+    def test_package_machine_does_not_get_first_server_type_if_server_type_specified(self):
+        package_machine(server_type='headless')
+
+        self.assertFalse(self.get_first_server_type.called)
+
+    def test_package_machine_gets_first_compute_type_if_no_compute_type_specified(self):
+        package_machine()
+
+        self.get_first_compute_type.assert_called_once_with()
+
+    def test_package_machine_does_not_get_first_compute_type_if_compute_type_specified(self):
+        package_machine(compute_type='vagrant')
+
+        self.assertFalse(self.get_first_compute_type.called)
+
+    def test_package_machine_does_not_retrieve_package_machine_config_if_only_check_available(self):
+        package_machine(only_check_available=True)
+
+        self.assertFalse(self.retrieve_package_machine_config.called)
+
+    def test_package_machine_does_not_run_package_command_if_only_check_available(self):
+        package_machine(only_check_available=True)
+
+        self.assertFalse(self.run_command.called)
+
+    def test_package_machine_retrieves_package_machine_config(self):
+        package_machine()
+
+        self.retrieve_package_machine_config.assert_called_once_with(
+            server_type=self.get_first_server_type.return_value,
+            compute_type=self.get_first_compute_type.return_value
+        )
+
+    def test_package_machine_runs_package_command(self):
+        package_machine()
+
+        self.run_command.assert_called_once_with(
+            self.retrieve_package_machine_config.return_value,
+            buffered=False,
+            shell=True
+        )

--- a/tests/unit/raptiformica/actions/package/test_retrieve_package_machine_config.py
+++ b/tests/unit/raptiformica/actions/package/test_retrieve_package_machine_config.py
@@ -1,0 +1,71 @@
+from raptiformica.actions.package import retrieve_package_machine_config
+from tests.testcase import TestCase
+
+
+class TestRetrievePackageMachineConfig(TestCase):
+    def setUp(self):
+        self.get_first_server_type = self.set_up_patch(
+            'raptiformica.actions.package.get_first_server_type'
+        )
+        self.get_first_server_type.return_value = 'headless'
+        self.get_first_compute_type = self.set_up_patch(
+            'raptiformica.actions.package.get_first_compute_type'
+        )
+        self.get_first_compute_type.return_value = 'vagrant'
+        self.get_config = self.set_up_patch(
+            'raptiformica.actions.package.get_config'
+        )
+        self.get_config.return_value = {
+            'raptiformica': {
+                'compute': {
+                    'vagrant': {
+                        'headless': {
+                            'package': 'cd some/directory && ./package.sh'
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_retrieve_package_machine_config_gets_first_server_type_if_no_server_type_specified(self):
+        retrieve_package_machine_config()
+
+        self.get_first_server_type.assert_called_once_with()
+
+    def test_retrieve_package_machine_config_does_not_get_first_server_type_if_server_type_specified(self):
+        retrieve_package_machine_config(server_type='headless')
+
+        self.assertFalse(self.get_first_server_type.called)
+
+    def test_retrieve_package_machine_config_gets_first_compute_type_if_no_compute_type_specified(self):
+        retrieve_package_machine_config()
+
+        self.get_first_compute_type.assert_called_once_with()
+
+    def test_retrieve_package_machine_config_does_not_get_first_compute_type_if_compute_type_specified(self):
+        retrieve_package_machine_config(compute_type='vagrant')
+
+        self.assertFalse(self.get_first_compute_type.called)
+
+    def test_retrieve_package_machine_config_gets_config(self):
+        retrieve_package_machine_config()
+
+        self.get_config.assert_called_once_with()
+
+    def test_retrieve_package_machine_config_returns_package_command(self):
+        ret = retrieve_package_machine_config()
+
+        self.assertEqual(ret, 'cd some/directory && ./package.sh')
+
+    def test_retrieve_package_machine_config_raises_error_when_no_such_server_type_configured(self):
+        with self.assertRaises(RuntimeError):
+            retrieve_package_machine_config(server_type='does_not_exist')
+
+    def test_retrieve_package_machine_config_raises_error_when_no_such_compute_type_configured(self):
+        with self.assertRaises(RuntimeError):
+            retrieve_package_machine_config(compute_type='does_not_exist')
+
+    def test_retrieve_package_machine_config_raises_error_when_no_package_command_configured(self):
+        del self.get_config.return_value['raptiformica']['compute']['vagrant']['headless']['package']
+        with self.assertRaises(RuntimeError):
+            retrieve_package_machine_config()

--- a/tests/unit/raptiformica/cli/test_package.py
+++ b/tests/unit/raptiformica/cli/test_package.py
@@ -1,0 +1,23 @@
+from raptiformica.cli import package
+from tests.testcase import TestCase
+
+
+class TestPackage(TestCase):
+    def setUp(self):
+        self.parse_package_arguments = self.set_up_patch('raptiformica.cli.parse_package_arguments')
+        self.args = self.parse_package_arguments.return_value
+        self.package_machine = self.set_up_patch('raptiformica.cli.package_machine')
+
+    def test_package_parses_package_arguments(self):
+        package()
+
+        self.parse_package_arguments.assert_called_once_with()
+
+    def test_package_packages_machine(self):
+        package()
+
+        self.package_machine.assert_called_once_with(
+            server_type=self.args.server_type,
+            compute_type=self.args.compute_type,
+            only_check_available=self.args.check_available
+        )

--- a/tests/unit/raptiformica/cli/test_parse_package_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_package_arguments.py
@@ -1,0 +1,69 @@
+from mock import call
+
+from raptiformica.cli import parse_package_arguments
+from tests.testcase import TestCase
+
+
+class TestParsePackageArguments(TestCase):
+    def setUp(self):
+        self.argument_parser = self.set_up_patch('raptiformica.cli.ArgumentParser')
+        self.parse_arguments = self.set_up_patch('raptiformica.cli.parse_arguments')
+        self.get_first_server_type = self.set_up_patch(
+            'raptiformica.cli.get_first_server_type'
+        )
+        self.get_first_server_type.return_value = 'headless'
+        self.get_first_compute_type = self.set_up_patch(
+            'raptiformica.cli.get_first_compute_type'
+        )
+        self.get_first_compute_type.return_value = 'vagrant'
+        self.get_server_types = self.set_up_patch(
+            'raptiformica.cli.get_server_types'
+        )
+        self.get_server_types.return_value = [
+            self.get_first_server_type.return_value
+        ]
+        self.get_compute_types = self.set_up_patch(
+            'raptiformica.cli.get_compute_types'
+        )
+        self.get_compute_types.return_value = [
+            self.get_first_compute_type.return_value
+        ]
+
+    def test_parse_package_arguments_instantiates_argparser(self):
+        parse_package_arguments()
+
+        self.argument_parser.assert_called_once_with(
+            prog='raptiformica package',
+            description='Package a compute type into a reusable image to speed up '
+                        'booting instances'
+        )
+
+    def test_parse_package_arguments_adds_arguments(self):
+        parse_package_arguments()
+
+        expected_calls = [
+            call('--server-type', type=str, default=self.get_first_server_type.return_value,
+                 choices=self.get_server_types.return_value,
+                 help='Specify a server type. Default is {}'.format(
+                         self.get_first_server_type.return_value)),
+            call('--compute-type', type=str, default=self.get_first_compute_type.return_value,
+                 choices=self.get_compute_types.return_value,
+                 help='Specify a compute type. Default is {}'.format(
+                         self.get_first_compute_type.return_value)),
+            call('--check-available', action='store_true',
+                 help='Check if there is a configured server and compute type available on this host')
+        ]
+        self.assertEqual(
+            self.argument_parser.return_value.add_argument.mock_calls,
+            expected_calls
+        )
+
+    def test_parse_package_arguments_parses_arguments(self):
+        parse_package_arguments()
+
+        self.parse_arguments.assert_called_once_with(self.argument_parser.return_value)
+
+    def test_parse_package_arguments_returns_parsed_arguments(self):
+        ret = parse_package_arguments()
+
+        self.assertEqual(ret, self.parse_arguments.return_value)


### PR DESCRIPTION
```
$ raptiformica package --help
usage: raptiformica package [-h] [--server-type {headless}]
                            [--compute-type {docker,vagrant}]
                            [--check-available] [--verbose]

Package a compute type into a reusable image to speed up booting instances

optional arguments:
  -h, --help            show this help message and exit
  --server-type {headless}
                        Specify a server type. Default is headless
  --compute-type {docker,vagrant}
                        Specify a compute type. Default is docker
  --check-available     Check if there is a configured server and compute type
                        available on this host
  --verbose, -v
```