### PR TITLE
do not accept empty response from kv store

### DIFF
--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -26,7 +26,7 @@ consul_conn = Connection(
 
 API_EXCEPTIONS = (HTTPError, HTTPException, URLError,
                   ConnectionRefusedError, ConnectionResetError,
-                  BadStatusLine, OSError)
+                  BadStatusLine, OSError, ValueError)
 
 
 def write_config_mapping(config, config_file):
@@ -115,7 +115,15 @@ def download_config_mapping():
         "Attempting to retrieve the shared config "
         "from the distributed key value store"
     )
-    return try_config_request(lambda: consul_conn.get_mapping(KEY_VALUE_PATH))
+    mapping = try_config_request(
+        lambda: consul_conn.get_mapping(KEY_VALUE_PATH)
+    )
+    if not mapping:
+        raise ValueError(
+            "Retrieved empty data from distributed key "
+            "value store. Not accepting."
+        )
+    return mapping
 
 
 def on_disk_mapping(module_dirs=(MODULES_DIR, USER_MODULES_DIR)):

--- a/tests/unit/raptiformica/settings/load/test_download_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_download_config_mapping.py
@@ -35,3 +35,9 @@ class TestDownloadConfigMapping(TestCase):
         download_config_mapping()
 
         try_config_request.assert_called_once_with(ANY)
+
+    def test_download_config_mapping_raises_value_error_if_returned_mapping_is_falsey(self):
+        self.get_mapping.return_value = None
+
+        with self.assertRaises(ValueError):
+            download_config_mapping()


### PR DESCRIPTION
so no invalid mappings are cached