### PR TITLE
log failure if failed to join consul peer

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -4,7 +4,8 @@ from shutil import rmtree
 
 from raptiformica.settings import CJDNS_DEFAULT_PORT, RAPTIFORMICA_DIR, KEY_VALUE_PATH
 from raptiformica.settings.load import get_config_mapping
-from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory, run_command, check_nonzero_exit
+from raptiformica.shell.execute import run_command_print_ready, run_command, check_nonzero_exit, \
+    log_failure_factory, raise_failure_factory
 from raptiformica.shell.hooks import fire_hooks
 from raptiformica.utils import load_json, write_json, ensure_directory, startswith, wait, group_n_elements, \
     calculate_checksum
@@ -533,8 +534,9 @@ def run_consul_join(ipv6_addresses):
     log.info("running: {}".format(consul_join_command))
     run_command_print_ready(
         consul_join_command,
-        failure_callback=raise_failure_factory(
-            "Failed to join the configured neighbours"
+        failure_callback=log_failure_factory(
+            "Failed to join the configured "
+            "neighbours {}".format(ipv6_addresses)
         ),
         shell=True,
         buffered=False

--- a/tests/unit/raptiformica/actions/mesh/test_run_consul_join.py
+++ b/tests/unit/raptiformica/actions/mesh/test_run_consul_join.py
@@ -7,8 +7,8 @@ from tests.testcase import TestCase
 class TestRunConsulJoin(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
-        self.raise_failure_factory = self.set_up_patch(
-            'raptiformica.actions.mesh.raise_failure_factory'
+        self.log_failure_factory = self.set_up_patch(
+            'raptiformica.actions.mesh.log_failure_factory'
         )
         self.run_command_print_ready = self.set_up_patch(
             'raptiformica.actions.mesh.run_command_print_ready'
@@ -23,11 +23,11 @@ class TestRunConsulJoin(TestCase):
     def test_run_consul_join_runs_consul_join_command(self):
         run_consul_join(self.ipv6_addresses)
 
-        self.raise_failure_factory.assert_called_once_with(ANY)
+        self.log_failure_factory.assert_called_once_with(ANY)
         expected_command = 'consul join [some_ipv6_address]:8301 [some_other_ipv6_address]:8301 '
         self.run_command_print_ready.assert_called_once_with(
             expected_command,
-            failure_callback=self.raise_failure_factory.return_value,
+            failure_callback=self.log_failure_factory.return_value,
             shell=True,
             buffered=False
         )


### PR DESCRIPTION
instead of raising error. If a consensus really could not be established
an error will be thrown later somewhere else.