### PR TITLE
flock reading config cache

### DIFF
--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -261,10 +261,13 @@ def cache_config_mapping(mapping):
 def cached_config_mapping():
     """
     Retrieve the cached config of the last successful config download
-    from distributed key value store
+    from distributed key value store. Waits with reading the cached
+    config until the exclusive lock can be acquired to prevent reading
+    truncated json because another process could be updating the cache.
     :return dict mapping: the k v config mapping
     """
-    return load_json(MUTABLE_CONFIG)
+    with config_cache_lock():
+        return load_json(MUTABLE_CONFIG)
 
 
 def get_local_config_mapping():

--- a/tests/unit/raptiformica/settings/load/test_cached_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_cached_config_mapping.py
@@ -3,11 +3,21 @@ from raptiformica.settings.load import cached_config_mapping
 from tests.testcase import TestCase
 
 
-class TestCachedConfig(TestCase):
+class TestCachedConfigMapping(TestCase):
     def setUp(self):
         self.load_json = self.set_up_patch(
             'raptiformica.settings.load.load_json'
         )
+        self.config_cache_lock = self.set_up_patch(
+            'raptiformica.settings.load.config_cache_lock'
+        )
+        self.config_cache_lock.return_value.__exit__ = lambda a, b, c, d: None
+        self.config_cache_lock.return_value.__enter__ = lambda a: None
+
+    def test_cached_config_gets_config_cache_lock_before_reading_cached_config(self):
+        cached_config_mapping()
+
+        self.config_cache_lock.assert_called_once_with()
 
     def test_cached_config_loads_mutable_config_as_json(self):
         cached_config_mapping()


### PR DESCRIPTION
so an incomplete cache that is still being written to disk is not read and parsed as json.

fixes:
```
    return cached_config_mapping()
  File "/usr/share/raptiformica/raptiformica/settings/load.py", line 267, in cached_config_mapping
    return load_json(MUTABLE_CONFIG)
  File "/usr/share/raptiformica/raptiformica/utils.py", line 19, in load_json
    return json.load(stream)
  File "/usr/lib/python3.4/json/__init__.py", line 268, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.4/json/__init__.py", line 318, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.4/json/decoder.py", line 343, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.4/json/decoder.py", line 361, in raw_decode
    raise ValueError(errmsg("Expecting value", s, err.value)) from None
ValueError: Expecting value: line 1 column 1 (char 0)
```