### PR TITLE
notify network reload

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -156,7 +156,12 @@ def configure_consul_conf():
                 'type': 'service',
                 'service': 'consul',
                 'handler': cluster_change_handler
-            }
+            },
+            {
+                'type': 'event',
+                'name': 'notify_cluster_change',
+                'handler': cluster_change_handler
+            },
         ]
     }
     for directory in ('/etc/consul.d', '/etc/opt/consul'):

--- a/raptiformica/distributed/events.py
+++ b/raptiformica/distributed/events.py
@@ -1,0 +1,61 @@
+from logging import getLogger
+
+from raptiformica.distributed.discovery import host_and_port_pairs_from_config
+from raptiformica.distributed.exec import try_machine_command
+
+
+log = getLogger(__name__)
+
+
+def try_send_consul_event(host_and_port_pairs, event_name):
+    """
+    Iterate over host and port pairs and try to send the event on each
+    of them until one returns a nonzero exit code. At that point return the standard
+    out output. If we ran out of host and port pairs to try, log a warning and return None
+    :param list[tuple, ..] host_and_port_pairs: A list of tuples containing host and ports
+    of remote hosts
+    :param str event_name: Name of the event to send
+    :return str consul_event_output | None: 'consul event' output or None
+    """
+
+    notify_cluster_change = ["consul", "event", "-name={}".format(event_name)]
+    attempt_message = "Trying to send {} event".format(
+        event_name
+    ) + " on {}:{}"
+    all_failed_message = "Could not send the event on any machine in the " \
+                         "distributed network. Maybe no meshnet has been " \
+                         "established yet."
+    output, _, _ = try_machine_command(
+        host_and_port_pairs,
+        notify_cluster_change,
+        attempt_message=attempt_message,
+        all_failed_message=all_failed_message
+    )
+    return output
+
+
+def send_reload_meshnet():
+    """
+    Refresh the cjdroute config and the consul config,
+    then reload the agents if necessary. When a new machine
+    is added to the network from the commandline of a machine
+    that is not in the network then that new machine will be
+    registered as a neighbour in the key value store of the
+    other bound machines on the machine running the commands.
+    However, updating the neighbours in the kv store is not
+    enough if the new machine can not directly reach the other
+    bound machines but the bound machines can reach the new machine.
+    In that case the bound machines (or at least one) will have to
+    add the new machine to their cjdroute config so they will reach
+    out to it and as soon as it comes online it will be able to contact
+    the bound nodes through the reverse tunnel transparently. By reloading
+    the meshnet configs this is achieved.
+    :return None:
+    """
+    log.info(
+        "Sending a meshnet config reload to all available machines"
+    )
+    # The 'notify_cluster_change' triggers the 'cluster_change_handler'
+    # watcher handler in the consul agent config. See actions/mesh.py
+    host_and_port_pairs = host_and_port_pairs_from_config()
+    try_send_consul_event(host_and_port_pairs, "notify_cluster_change")

--- a/raptiformica/distributed/proxy.py
+++ b/raptiformica/distributed/proxy.py
@@ -1,8 +1,7 @@
 from contextlib import contextmanager
 
-from raptiformica.distributed.discovery import host_and_port_pairs_from_config
+import raptiformica.distributed.discovery
 from raptiformica.distributed.exec import try_machine_command
-
 from raptiformica.shell.ssh import forward_remote_port
 
 
@@ -19,7 +18,8 @@ def forward_any_port(source_port, destination_port=None, predicate=None):
     :return None:
     """
     predicate = predicate or ['/bin/true']
-    host_and_port_pairs = host_and_port_pairs_from_config(cached=True)
+    host_and_port_pairs = raptiformica.distributed.discovery.\
+        host_and_port_pairs_from_config(cached=True)
     _, host, ssh_port = try_machine_command(
         host_and_port_pairs, predicate, attempt_limit=1
     )

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -2,6 +2,7 @@ import uuid
 from os.path import join
 from logging import getLogger
 
+from raptiformica.distributed.events import send_reload_meshnet
 from raptiformica.settings import CJDNS_DEFAULT_PORT, KEY_VALUE_PATH
 from raptiformica.settings.load import get_config_mapping, try_update_config_mapping
 from raptiformica.shell import cjdns
@@ -81,7 +82,7 @@ def update_neighbours_config(host, port=22, uuid=None):
 
 def update_meshnet_config(host, port=22, compute_checkout_uuid=None):
     """
-    Add a host to the local mutable config
+    Add a host to the distributed key value config mapping
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
     :param str compute_checkout_uuid: identifier for a local compute checkout
@@ -95,3 +96,4 @@ def update_meshnet_config(host, port=22, compute_checkout_uuid=None):
     update_neighbours_config(
         host, port=port, uuid=compute_checkout_uuid
     )
+    send_reload_meshnet()

--- a/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
@@ -91,7 +91,17 @@ class TestConfigureConsulConf(TestCase):
                                "./bin/raptiformica_hook.py cluster_change "
                                "--verbose"
                                "\""
-                }
+                },
+                {
+                    'type': 'event',
+                    'name': 'notify_cluster_change',
+                    'handler': "bash -c \""
+                               "cd '/usr/etc/raptiformica'; "
+                               "export PYTHONPATH=.; "
+                               "./bin/raptiformica_hook.py cluster_change "
+                               "--verbose"
+                               "\""
+                },
             ]
         }
         self.write_json.assert_called_once_with(

--- a/tests/unit/raptiformica/distributed/events/test_send_reload_meshnet.py
+++ b/tests/unit/raptiformica/distributed/events/test_send_reload_meshnet.py
@@ -1,0 +1,35 @@
+from mock import ANY
+
+from raptiformica.distributed.events import send_reload_meshnet
+from tests.testcase import TestCase
+
+
+class TestSendReloadMeshnet(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch(
+            'raptiformica.distributed.events.log'
+        )
+        self.host_and_port_pairs_from_config = self.set_up_patch(
+            'raptiformica.distributed.events.host_and_port_pairs_from_config'
+        )
+        self.try_send_consul_event = self.set_up_patch(
+            'raptiformica.distributed.events.try_send_consul_event'
+        )
+
+    def test_send_reload_meshnet_logs_sending_reload_message(self):
+        send_reload_meshnet()
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_send_reload_meshnet_gets_host_and_port_pairs_from_config(self):
+        send_reload_meshnet()
+
+        self.host_and_port_pairs_from_config.assert_called_once_with()
+
+    def test_send_reload_meshnet_tries_sending_notify_cluster_change_event(self):
+        send_reload_meshnet()
+
+        self.try_send_consul_event.assert_called_once_with(
+            self.host_and_port_pairs_from_config.return_value,
+            'notify_cluster_change'
+        )

--- a/tests/unit/raptiformica/distributed/events/test_try_send_consul_event.py
+++ b/tests/unit/raptiformica/distributed/events/test_try_send_consul_event.py
@@ -1,0 +1,32 @@
+from raptiformica.distributed.events import try_send_consul_event
+from tests.testcase import TestCase
+
+
+class TestTrySendConsulEvent(TestCase):
+    def setUp(self):
+        self.try_machine_command = self.set_up_patch(
+            'raptiformica.distributed.events.try_machine_command'
+        )
+        self.try_machine_command.return_value = ('output', '5.6.7.8', '22')
+        self.host_and_port_pairs = [
+            ('1.2.3.4', '2222'),
+            ('5.6.7.8', '22')
+        ]
+
+    def test_try_send_consul_event_tries_machine_command(self):
+        try_send_consul_event(self.host_and_port_pairs, 'notify_cluster_change')
+
+        expected_command = ['consul', 'event', '-name=notify_cluster_change']
+        self.try_machine_command.assert_called_once_with(
+            self.host_and_port_pairs,
+            expected_command,
+            attempt_message="Trying to send notify_cluster_change event on {}:{}",
+            all_failed_message="Could not send the event on any machine in the "
+                               "distributed network. Maybe no meshnet has been "
+                               "established yet."
+        )
+
+    def test_try_send_consul_event_returns_output_from_first_successful_sent_event(self):
+        ret = try_send_consul_event(self.host_and_port_pairs, 'notify_cluster_change')
+
+        self.assertEqual(ret, 'output')

--- a/tests/unit/raptiformica/distributed/proxy/test_forward_any_port.py
+++ b/tests/unit/raptiformica/distributed/proxy/test_forward_any_port.py
@@ -1,6 +1,6 @@
 from mock import Mock
 
-from raptiformica.distributed.proxy import forward_any_port
+import raptiformica.distributed.proxy
 from tests.testcase import TestCase
 
 
@@ -12,7 +12,7 @@ class TestForwardAnyPort(TestCase):
         self.forward_remote_port.return_value.__exit__ = Mock()
         self.forward_remote_port.return_value.__enter__ = Mock()
         self.host_and_port_pairs_from_config = self.set_up_patch(
-            'raptiformica.distributed.proxy.host_and_port_pairs_from_config'
+            'raptiformica.distributed.discovery.host_and_port_pairs_from_config'
         )
         self.try_machine_command = self.set_up_patch(
             'raptiformica.distributed.proxy.try_machine_command'
@@ -20,7 +20,7 @@ class TestForwardAnyPort(TestCase):
         self.try_machine_command.return_value = (0, '1.2.3.4', 1122)
 
     def test_forward_any_port_gets_cached_host_and_port_pairs(self):
-        with forward_any_port(8500):
+        with raptiformica.distributed.proxy.forward_any_port(8500):
             pass
 
         self.host_and_port_pairs_from_config.assert_called_once_with(
@@ -28,7 +28,7 @@ class TestForwardAnyPort(TestCase):
         )
 
     def test_forward_any_port_tries_finding_eligible_neighbour_one_time(self):
-        with forward_any_port(8500):
+        with raptiformica.distributed.proxy.forward_any_port(8500):
             pass
 
         self.try_machine_command.assert_called_once_with(
@@ -38,7 +38,9 @@ class TestForwardAnyPort(TestCase):
         )
 
     def test_forward_any_port_tries_finding_eligible_neighbour_with_specified_predicate(self):
-        with forward_any_port(8500, predicate=['consul', 'members']):
+        with raptiformica.distributed.proxy.forward_any_port(
+            8500, predicate=['consul', 'members']
+        ):
             pass
 
         self.try_machine_command.assert_called_once_with(
@@ -51,14 +53,14 @@ class TestForwardAnyPort(TestCase):
         self.try_machine_command.return_value = (None, None, None)
 
         with self.assertRaises(RuntimeError):
-            with forward_any_port(8500):
+            with raptiformica.distributed.proxy.forward_any_port(8500):
                 pass
 
     def test_forward_any_port_forwards_remote_port_in_context(self):
         self.assertFalse(self.forward_remote_port.return_value.__enter__.called)
         self.assertFalse(self.forward_remote_port.return_value.__exit__.called)
 
-        with forward_any_port(8500):
+        with raptiformica.distributed.proxy.forward_any_port(8500):
             self.assertTrue(self.forward_remote_port.return_value.__enter__.called)
             self.assertFalse(self.forward_remote_port.return_value.__exit__.called)
 

--- a/tests/unit/raptiformica/settings/load/test_try_config_request.py
+++ b/tests/unit/raptiformica/settings/load/test_try_config_request.py
@@ -9,7 +9,7 @@ class TestTryConfigRequest(TestCase):
     def setUp(self):
         self.callback = Mock()
         self.forward_any_port = self.set_up_patch(
-            'raptiformica.settings.load.forward_any_port'
+            'raptiformica.distributed.proxy.forward_any_port'
         )
         self.forward_any_port.return_value.__exit__ = lambda a, b, c, d: None
         self.forward_any_port.return_value.__enter__ = lambda a: None

--- a/tests/unit/raptiformica/settings/meshnet/test_update_meshnet_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_meshnet_config.py
@@ -8,6 +8,7 @@ class TestUpdateMeshnetConfig(TestCase):
         self.update_cjdns_config = self.set_up_patch('raptiformica.settings.meshnet.update_cjdns_config')
         self.update_consul_config = self.set_up_patch('raptiformica.settings.meshnet.update_consul_config')
         self.update_neighbours_config = self.set_up_patch('raptiformica.settings.meshnet.update_neighbours_config')
+        self.send_reload_meshnet = self.set_up_patch('raptiformica.settings.meshnet.send_reload_meshnet')
 
     def test_update_meshnet_config_logs_updating_meshnet_config_message(self):
         update_meshnet_config('1.2.3.4', port=2222)
@@ -39,3 +40,8 @@ class TestUpdateMeshnetConfig(TestCase):
         self.update_neighbours_config.assert_called_once_with(
             '1.2.3.4', port=2222, uuid='some_uuid_1234'
         )
+
+    def test_update_meshnet_config_reloads_meshnet(self):
+        update_meshnet_config('1.2.3.4', port=2222)
+
+        self.send_reload_meshnet.assert_called_once_with()


### PR DESCRIPTION
when a new machine is added to the distributed kv store config

- uses a consul watcher that will reload cjdroute and consul if necessary
- tries to send the event on one of its peers so the command line
  executor does not have to be part of the network

this is needed for when a machine which is not in the network but has a
config that can talk to machine b which is in the network tries to join
machine c which can not reach b directly but can be reached by b. b will
then create a reverse tunnel to c so that c then can connect to b
transparently as if it could reach it directly.