### PR TITLE
download rsync ignores missing args

### DIFF
--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -21,6 +21,7 @@ def download(source, destination, host, port=22):
     """
     download_command = [
         '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz',
+        '-ignore-missing-args',  # Don't warn when downloading from self
         'root@{}:{}'.format(host, source), destination,
         '--exclude=.venv', '--exclude=*.pyc',
         '-e', 'ssh -p {} '

--- a/tests/unit/raptiformica/shell/rsync/test_download.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download.py
@@ -16,6 +16,7 @@ class TestDownload(TestCase):
 
         expected_download_command = [
             '/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz',
+            '-ignore-missing-args',  # Don't warn when downloading from self
             'root@1.2.3.4:{}'.format(PROJECT_DIR),
             INSTALL_DIR, '--exclude=.venv',
             '--exclude=*.pyc', '-e', 'ssh -p 22 '


### PR DESCRIPTION
so the system can assimilate the host it is running on over SSH without creating a corrupted file sync list when including symlinks / git submodules

fixes:
```
Downloading artifacts from the remote host
Running command: ['/usr/bin/env', 'rsync', '-q', '-a', '-L', '-avz', 'root@192.168.1.123:.raptiformica.d/artifacts', '/root/.raptiformica.d', '--exclude=.venv', '--exclude=*.pyc', '-e', 'ssh -p 22 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null']
Traceback (most recent call last):
  File "/usr/share/raptiformica/bin/raptiformica_slave.py", line 5, in <module>
    slave()
  File "/usr/share/raptiformica/raptiformica/cli.py", line 67, in slave
    server_type=args.server_type
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 97, in slave_machine
    assimilate_machine(host, port=port, uuid=uuid)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 62, in assimilate_machine
    download_artifacts(host, port=port)
  File "/usr/share/raptiformica/raptiformica/shell/rsync.py", line 110, in download_artifacts
    join(CACHE_DIR, 'artifacts'), ABS_CACHE_DIR
  File "/usr/share/raptiformica/raptiformica/shell/rsync.py", line 38, in download
    buffered=False
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 265, in run_command_print_ready
    buffered=buffered, shell=shell
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 186, in run_command
    buffered=buffered, shell=shell
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 113, in run_command_locally
    failure_callback(process_output)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 199, in print_ready_callback
    callback(make_process_output_print_ready(process_output))
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 18, in raise_failure
    raise RuntimeError("{}\n{}".format(message, standard_error))
RuntimeError: Something went wrong downloading files from the remote host
Warning: Permanently added '192.168.1.123' (ECDSA) to the list of known hosts.
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/Dockerfile"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/admin/README.md"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/debian/cjdns-dynamic.upstart"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/debian/cjdns.service"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/debian/cjdns.upstart"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/tunnel/README.md"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/raptiformica_default_provisioner/consul_kv/__init__.py"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/raptiformica_default_provisioner/consul_kv/api.py"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/raptiformica_default_provisioner/consul_kv/serializer.py"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/raptiformica_default_provisioner/consul_kv/settings.py"
file has vanished: "/root/.raptiformica.d/artifacts/repositories/raptiformica_default_provisioner/consul_kv/utils.py"
rsync warning: some files vanished before they could be transferred (code 24) at main.c(1650) [generator=3.1.2]
```