### PR TITLE
linked cluster test

### DIFF
--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -1,0 +1,82 @@
+from tests.testcase import IntegrationTestCase
+
+
+class TestLinkedCluster(IntegrationTestCase):
+    """
+    Test a linked cluster of three Docker instances. This test case simulates a
+    situation where instance A can reach B using an address that only has meaning
+    to A. The same goes for B to C. This means that the address that A uses to connect
+    to B can not be used by C to connect to B. The address used by B to connect to C can
+    not be used by A to connect to C. A is unreachable fo C and the other way around.
+
+    The only path is then:
+
+    .===.   .===.   .===.
+    | A |->-| B |->-| C |
+    '==='   '==='   '==='
+
+    This scenario tests whether starting from A, slaving B will create a reverse
+    route using CJDNS from B to A and that slaving C from B will create another
+    reverse route. C should then be able to connect to A using the two tunnels
+    and vice versa. This simulates a firewalled scenario where a host can connect
+    to another host which then can also connect to yet another host, one that is
+    not accessible by the first host.
+    """
+    def spawn_docker_instances(self):
+        self.run_raptiformica_command("spawn --no-assimilate --server-type headless --compute-type docker")
+
+    def setUp(self):
+        super(TestLinkedCluster, self).setUp()
+        self.amount_of_instances = 3
+
+        # Spawn 3 un-assimilated Docker instances
+        for _ in range(self.amount_of_instances):
+            self.spawn_docker_instances()
+
+        # List the spawned instances and their IPs
+        docker_instances = self.list_docker_instances()
+        docker_ips = list(map(self.get_docker_ip, docker_instances))
+
+        # Ensure the requirements are installed
+        self.ensure_raptiformica_requirements(docker_instances)
+
+        # Make the first instance DNAT 1.2.3.4 to 172.17.0.4 etc
+        first_instance_firewalled_ips = list(
+            self.pretend_behind_firewall(docker_instances[0], docker_ips, subnet="1.2.3.{}")
+        )
+
+        # Make the second instance DNAT 2.2.3.4 to 172.17.0.4 etc
+        second_instance_firewalled_ips = list(
+            self.pretend_behind_firewall(docker_instances[1], docker_ips, subnet="2.3.4.{}")
+        )
+
+        # Assimilate one of the instances from the client (which is not in the cluster)
+        # so we can later run raptiformica members without having to log in explicitly.
+        self.run_raptiformica_command(
+            "slave {} --server-type headless --verbose".format(docker_ips[0])
+        )
+
+        # Install the uploaded raptiformica systemwide on the first two instances
+        # so we can run 'raptiformica' without having to specify the PYTHONPATH and
+        # project path.
+        for i in range(2):
+            self.install_raptiformica_in_docker(docker_instances[i])
+            # Make sure the instance has no lingering data
+            self.clear_mutable_config(docker_instances[i])
+
+        # Perform the raptiformica command on the first instance
+        # A will assimilate A, then A will assimilate B.
+        self.slave_from_firewalled_environment(docker_ips[0], docker_ips[:1])
+        self.slave_from_firewalled_environment(
+            docker_ips[0], first_instance_firewalled_ips[1:2]
+        )
+
+        # Perform the raptiformica command on the second instance
+        # B will assimilate C
+        self.slave_from_firewalled_environment(
+            docker_ips[1], second_instance_firewalled_ips[2:]
+        )
+
+    def test_linked_cluster_establishes_mesh_correctly(self):
+        self.check_consul_consensus_was_established(expected_peers=self.amount_of_instances)
+        self.check_all_registered_peers_can_be_pinged_from_any_instance()

--- a/tests/integration/meshnet/test_simple_cluster.py
+++ b/tests/integration/meshnet/test_simple_cluster.py
@@ -10,7 +10,7 @@ class TestSimpleCluster(IntegrationTestCase):
 
     .===.   .===.   .===.
     | A |<->| B |<->| C |
-    '=|='   '==='   '-|-'
+    '=|='   '==='   '=|='
       '======<=>======'
 
     This simulates a subnet in a data-center for example.

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -1,6 +1,3 @@
-from functools import partial
-
-from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory
 from tests.testcase import IntegrationTestCase
 
 
@@ -16,7 +13,7 @@ class TestTreeCluster(IntegrationTestCase):
 
     .===.   .===.   .===.
     | A |->-| B |   | C |
-    '=|='   '==='   '-|-'
+    '=|='   '==='   '=|='
       '=======>======='
 
     This scenario tests whether starting from A, slaving B will create a reverse
@@ -28,123 +25,6 @@ class TestTreeCluster(IntegrationTestCase):
     """
     def spawn_docker_instances(self):
         self.run_raptiformica_command("spawn --no-assimilate --server-type headless --compute-type docker")
-
-    def ensure_package_installed(self, docker_instance, package):
-        install_package_command = "sudo docker exec {} apt-get install " \
-                                  "{} -yy".format(docker_instance, package)
-        run_command_print_ready(
-            install_package_command, buffered=False, shell=True,
-            failure_callback=raise_failure_factory(
-                "Failed to install {} on the testhost. Could not set up "
-                "the scenario for TestTreeCluster :(".format(package)
-            )
-        )
-
-    def ensure_raptiformica_installed(self, docker_instance):
-        install_raptiformica_command = "sudo docker exec {} bash -c '" \
-                                       "cd /usr/etc/raptiformica; " \
-                                       "make install'" \
-                                       "".format(docker_instance)
-        run_command_print_ready(
-            install_raptiformica_command, buffered=False, shell=True,
-            failure_callback=raise_failure_factory(
-                "Failed to install raptiformica on the testhost. "
-                "Could not set up the scenario for TestTreeCluster :("
-            )
-        )
-
-    def preroute_docker_ip(self, docker_instance, docker_ip):
-        last_octet = docker_ip.split('.')[-1]
-        natted_ip = "1.2.3.{}".format(last_octet)
-        preroute_ip_commmand = "sudo docker exec {} " \
-                               "iptables -t nat -A OUTPUT -p all " \
-                               "-d {} -j DNAT " \
-                               "--to-destination {}" \
-                               "".format(docker_instance,
-                                         natted_ip, docker_ip)
-        run_command_print_ready(
-            preroute_ip_commmand, buffered=False, shell=True,
-            failure_callback=raise_failure_factory(
-                "Failed to install prerouting rule for {} on the testhost. "
-                "Could not set up the scenario for TestTreeCluster :("
-                "".format(docker_ip)
-            )
-        )
-        return natted_ip
-
-    def pretend_behind_firewall(self, docker_instance, docker_ips):
-        """
-        Add iptables rules to the instance so that the docker IPs can be
-        reached through an aliased IP. This way the system will propagate
-        those IPs to the other instances but they won't be able to reach
-        the addresses because they will route to nothing because those
-        other instances don't have the pre-routing rules.
-        :param str docker_instance: ID of the Docker instance to perform
-        the aliased routing on
-        :param list docker_ips: List of IPs to re-route
-        :return iter NATted_ips: The re-routed IPs
-        """
-        self.ensure_package_installed(docker_instance, 'iptables')
-        return map(partial(self.preroute_docker_ip, docker_instance), docker_ips)
-
-    def ensure_raptiformica_requirements(self, docker_instances):
-        """
-        Install the requirements for raptiformica
-        :param list [str instance, ..] docker_instances: List of docker instances
-        :return None:
-        """
-        for docker_instance in docker_instances:
-            for package in ('make', 'sudo', 'iputils-ping'):
-                self.ensure_package_installed(docker_instance, package)
-
-    def clear_mutable_config(self, docker_instance):
-        """
-        Remove the mutable config in a docker
-        :param str docker_instance: ID of the Docker instance to clear the
-        mutable config on
-        :return None:
-        """
-        clear_mutable_config = "sudo docker exec {} " \
-                               "rm -f /root/.raptiformica.d/mutable_config.json" \
-                               "".format(docker_instance)
-        run_command_print_ready(
-            clear_mutable_config, buffered=False, shell=True,
-            failure_callback=raise_failure_factory(
-                "Failed to clear the cached config on the testhost. "
-                "Could not set up the scenario for TestTreeCluster :("
-            )
-        )
-
-    def install_raptiformica_in_docker(self, docker_instance):
-        """
-        Install raptiformica system wide in the instance
-        :param str docker_instance: ID of the Docker instance to install
-        raptiformica system wide in
-        :return None:
-        """
-        self.ensure_raptiformica_installed(docker_instance)
-
-    def slave_from_firewalled_environment(self, docker_ip, NATted_ips):
-        """
-        Slave the Docker instances from behind the firewall.
-        :param str docker_ip: IP of the Docker instance to perform
-        the raptiformica commands on
-        :param list NATted_ips: list of the NATted IPs to slave
-        :return None:
-        """
-        for NATted_ip in NATted_ips:
-            slave_instance_command = "ssh -oStrictHostKeyChecking=no " \
-                                     "-oUserKnownHostsFile=/dev/null " \
-                                     "-A root@{} raptiformica " \
-                                     "slave {} --verbose" \
-                                     "".format(docker_ip, NATted_ip)
-            run_command_print_ready(
-                slave_instance_command, buffered=False, shell=True,
-                failure_callback=raise_failure_factory(
-                    "Failed to slave the NATted ip {}. Could not set up "
-                    "the scenario for TestTreeCluster :(".format(NATted_ip)
-                )
-            )
 
     def setUp(self):
         super(TestTreeCluster, self).setUp()
@@ -182,6 +62,6 @@ class TestTreeCluster(IntegrationTestCase):
         self.slave_from_firewalled_environment(docker_ips[0], docker_ips[:1])
         self.slave_from_firewalled_environment(docker_ips[0], NATted_ips[1:])
 
-    def test_simple_cluster_establishes_mesh_correctly(self):
+    def test_tree_cluster_establishes_mesh_correctly(self):
         self.check_consul_consensus_was_established(expected_peers=self.amount_of_instances)
         self.check_all_registered_peers_can_be_pinged_from_any_instance()


### PR DESCRIPTION
Test a linked cluster of three Docker instances. This test case simulates a
situation where instance A can reach B using an address that only has meaning
to A. The same goes for B to C. This means that the address that A uses to connect
to B can not be used by C to connect to B. The address used by B to connect to C can
not be used by A to connect to C. A is unreachable to C and the other way around.

The only path is then:

```
.===.   .===.   .===.
| A |->-| B |->-| C |
'==='   '==='   '==='
```

This scenario tests whether starting from A, slaving B will create a reverse
route using CJDNS from B to A and that slaving C from B will create another
reverse route. C should then be able to connect to A using the two tunnels
and vice versa. This simulates a firewalled scenario where a host can connect
to another host which then can also connect to yet another host, one that is
not accessible by the first host.