### PR TITLE
use global conf object

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -2,7 +2,7 @@ from os.path import join, isfile
 from logging import getLogger
 from shutil import rmtree
 
-from raptiformica.settings import CJDNS_DEFAULT_PORT, RAPTIFORMICA_DIR, KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config_mapping
 from raptiformica.shell.execute import run_command_print_ready, run_command, check_nonzero_exit, \
     log_failure_factory, raise_failure_factory
@@ -26,7 +26,7 @@ def list_neighbours(mapping):
     :param dict mapping: the config mapping to parse the neighbours from
     :return iter[str, ..]: public keys of all neighbours in the config
     """
-    neighbours_path = "{}/meshnet/neighbours/".format(KEY_VALUE_PATH)
+    neighbours_path = "{}/meshnet/neighbours/".format(conf().KEY_VALUE_PATH)
     public_keys = set(map(
         lambda p: p.replace(neighbours_path, '').split('/')[0],
         filter(
@@ -43,7 +43,7 @@ def get_cjdns_password(mapping):
     :param dict mapping: the config mapping to get the shared secret from
     :return str secret: the shared cjdns secret
     """
-    return mapping["{}/meshnet/cjdns/password".format(KEY_VALUE_PATH)]
+    return mapping["{}/meshnet/cjdns/password".format(conf().KEY_VALUE_PATH)]
 
 
 def get_consul_password(mapping):
@@ -52,7 +52,7 @@ def get_consul_password(mapping):
     :param dict mapping: the config mapping to get the shared secret from
     :return str secret: the shared consul secret
     """
-    return mapping["{}/meshnet/consul/password".format(KEY_VALUE_PATH)]
+    return mapping["{}/meshnet/consul/password".format(conf().KEY_VALUE_PATH)]
 
 
 def parse_cjdns_neighbours(mapping):
@@ -69,7 +69,7 @@ def parse_cjdns_neighbours(mapping):
     local_public_key = cjdroute_config['publicKey']
 
     neighbours_path = "{}/meshnet/neighbours/".format(
-        KEY_VALUE_PATH
+        conf().KEY_VALUE_PATH
     )
     public_keys = list_neighbours(mapping)
     for pk in public_keys:
@@ -105,7 +105,7 @@ def configure_cjdroute_conf():
     neighbours = parse_cjdns_neighbours(mapping)
     cjdroute_config['interfaces']['UDPInterface'] = [{
         'connectTo': neighbours,
-        'bind': '0.0.0.0:{}'.format(CJDNS_DEFAULT_PORT)
+        'bind': '0.0.0.0:{}'.format(conf().CJDNS_DEFAULT_PORT)
     }]
     write_json(cjdroute_config, CJDROUTE_CONF_PATH)
 
@@ -123,7 +123,7 @@ def configure_consul_conf():
                              "cd '{}'; " \
                              "export PYTHONPATH=.; " \
                              "./bin/raptiformica_hook.py cluster_change " \
-                             "--verbose\"".format(RAPTIFORMICA_DIR)
+                             "--verbose\"".format(conf().RAPTIFORMICA_DIR)
     shared_secret = get_consul_password(get_config_mapping())
     consul_config = {
         'bootstrap_expect': 3,
@@ -514,7 +514,7 @@ def get_neighbour_hosts(mapping):
     :param dict mapping: Key value mapping with the config data
     :return list ipv6_addresses: All known neighbour hosts
     """
-    neighbours_path = "{}/meshnet/neighbours/".format(KEY_VALUE_PATH)
+    neighbours_path = "{}/meshnet/neighbours/".format(conf().KEY_VALUE_PATH)
     public_keys = list_neighbours(mapping)
     ipv6_addresses = list()
     for pk in public_keys:

--- a/raptiformica/actions/modules.py
+++ b/raptiformica/actions/modules.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from shutil import rmtree
 
-from raptiformica.settings import USER_MODULES_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import on_disk_mapping, try_delete_config, try_update_config_mapping
 from raptiformica.shell.git import clone_source
 
@@ -39,7 +39,7 @@ def retrieve_module(module_name):
     log.debug("Cloning from {}".format(url))
     clone_source(
         url,
-        join(USER_MODULES_DIR, directory)
+        join(conf().USER_MODULES_DIR, directory)
     )
 
 
@@ -50,7 +50,7 @@ def load_configs(module_name):
     :return:
     """
     _, directory = determine_clone_data(module_name)
-    module_directory = join(USER_MODULES_DIR, directory)
+    module_directory = join(conf().USER_MODULES_DIR, directory)
     mapping = on_disk_mapping(module_dirs=(module_directory,))
     log.debug("Loading keys for {} into the config".format(module_name))
     try_update_config_mapping(mapping)
@@ -100,7 +100,7 @@ def unload_module(module_name):
     :return None:
     """
     _, directory = determine_clone_data(module_name)
-    module_directory = join(USER_MODULES_DIR, directory)
+    module_directory = join(conf().USER_MODULES_DIR, directory)
     mapping = on_disk_mapping(module_dirs=(module_directory,))
     remove_keys(mapping, module_directory)
     refresh_keys(mapping)

--- a/raptiformica/actions/package.py
+++ b/raptiformica/actions/package.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from raptiformica.settings import KEY_VALUE_PATH, PROJECT_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config
 from raptiformica.settings.types import get_first_server_type, get_first_compute_type
 from raptiformica.shell.execute import run_command_in_directory_factory
@@ -18,7 +18,7 @@ def retrieve_package_machine_config(server_type=None, compute_type=None):
     server_type = server_type or get_first_server_type()
     compute_type = compute_type or get_first_compute_type()
     config = get_config()
-    server_config = config[KEY_VALUE_PATH][
+    server_config = config[conf().KEY_VALUE_PATH][
         'compute'
     ].get(compute_type, {}).get(server_type, {})
     if 'package' not in server_config:
@@ -48,6 +48,6 @@ def package_machine(server_type=None, compute_type=None, only_check_available=Fa
             server_type=server_type, compute_type=compute_type
         )
         run_package_command = run_command_in_directory_factory(
-            PROJECT_DIR, package_command
+            conf().PROJECT_DIR, package_command
         )
         run_package_command(buffered=False)

--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -3,7 +3,7 @@ from os import listdir
 from os.path import join, isdir
 from shutil import rmtree
 
-from raptiformica.settings import EPHEMERAL_DIR, MACHINES_DIR, KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import try_delete_config, get_config
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type, \
     retrieve_compute_type_config_for_server_type, get_compute_types, get_server_types
@@ -63,7 +63,8 @@ def list_compute_checkouts_for_server_type_of_compute_type(server_type, compute_
     item the server type, the second item the compute checkout and the third item the directory of the checkout
     """
     compute_checkouts = list()
-    directories = EPHEMERAL_DIR, MACHINES_DIR, compute_type, server_type
+    directories = conf().EPHEMERAL_DIR, conf().MACHINES_DIR, compute_type, \
+        server_type
     server_type_of_compute_type_directory = join(*directories)
     if isdir(server_type_of_compute_type_directory):
         for compute_checkout in listdir(server_type_of_compute_type_directory):
@@ -172,10 +173,10 @@ def get_neighbours_by_uuid(uuid):
     Should only be one, but in case there are more those should also be dealt with.
     """
     config = get_config()
-    meshnet_config = config[KEY_VALUE_PATH].get('meshnet', {})
+    meshnet_config = config[conf().KEY_VALUE_PATH].get('meshnet', {})
     neighbours = meshnet_config.get('neighbours', {})
     return [
-        '{}/meshnet/neighbours/{}/'.format(KEY_VALUE_PATH, k)
+        '{}/meshnet/neighbours/{}/'.format(conf().KEY_VALUE_PATH, k)
         for k, v in neighbours.items() if v['uuid'] == uuid
     ]
 

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config
 from raptiformica.settings.meshnet import ensure_route_to_new_neighbour
 from raptiformica.settings.types import get_first_server_type
@@ -22,7 +22,7 @@ def retrieve_provisioning_configs(server_type=None):
     log.debug("Retrieving provisioning config")
     server_type = server_type or get_first_server_type()
     config = get_config()
-    server_types = config[KEY_VALUE_PATH]['server']
+    server_types = config[conf().KEY_VALUE_PATH]['server']
     server_type = server_types.get(server_type, {})
     return {k: {'source': v['source'], 'bootstrap': v['bootstrap']}
             for k, v in server_type.items()}

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 from raptiformica.actions.slave import slave_machine
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config_mapping
 from raptiformica.settings.types import get_first_compute_type, get_first_server_type
 from raptiformica.shell.compute import start_instance
@@ -25,7 +25,7 @@ def retrieve_start_instance_config(server_type=None, compute_type=None):
     mapped = get_config_mapping()
 
     start_instance_path = '{}/compute/{}/{}/'.format(
-        KEY_VALUE_PATH, compute_type, server_type
+        conf().KEY_VALUE_PATH, compute_type, server_type
     )
     start_instance_keys = list(filter(
         startswith(start_instance_path),

--- a/raptiformica/distributed/discovery.py
+++ b/raptiformica/distributed/discovery.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 import raptiformica.settings.load
 
 
@@ -11,6 +11,6 @@ def host_and_port_pairs_from_config(cached=False):
     """
     # Absolute import to prevent circular import
     config = raptiformica.settings.load.get_config(cached=cached)
-    meshnet_config = config[KEY_VALUE_PATH].get('meshnet', {})
+    meshnet_config = config[conf().KEY_VALUE_PATH].get('meshnet', {})
     neighbours = meshnet_config.get('neighbours', {})
     return [(n['host'], n['ssh_port']) for n in neighbours.values()]

--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -2,46 +2,49 @@ from os.path import dirname, realpath, join, expanduser
 from platform import uname
 
 
-PROJECT_DIR = join(dirname(dirname(dirname(realpath(__file__)))))
-INSTALL_DIR = '/usr/etc/'
-RAPTIFORMICA_DIR = join(INSTALL_DIR, 'raptiformica')
-CONSUL_WEB_UI_DIR = join(INSTALL_DIR, 'consul_web_ui')
-CACHE_DIR = ".raptiformica.d"
-ABS_CACHE_DIR = join(expanduser("~"), CACHE_DIR)
-EPHEMERAL_DIR = join(ABS_CACHE_DIR, 'var')
-SCRIPTS_DIR = join(PROJECT_DIR, 'scripts')
-MACHINES_DIR = join(EPHEMERAL_DIR, 'machines')
-BASE_CONFIG = join(PROJECT_DIR, '.base_config.json')
-MUTABLE_CONFIG = join(ABS_CACHE_DIR, 'mutable_config.json')
-CONFIG_CACHE_LOCK = '/tmp/raptiformica_config_cache.lock'
-MODULES_DIR = join(PROJECT_DIR, 'modules')
-USER_MODULES_DIR = join(ABS_CACHE_DIR, 'modules')
-USER_ARTIFACTS_DIR = join(ABS_CACHE_DIR, 'artifacts')
-KEY_VALUE_ENDPOINT = 'http://localhost:8500/v1/kv'
-KEY_VALUE_TIMEOUT = 1  # How long to wait for a config retrieval
-KEY_VALUE_PATH = 'raptiformica'
-CJDNS_DEFAULT_PORT = 4863
-MACHINE_ARCH = uname()[4]
-
-
-def set_cache_dir(cache_dir):
-    """
-    Update the settings relative cache dir during runtime
-    :param str cache_dir: The cache dir to set
-    :return None:
-    """
-    global CACHE_DIR
-    global ABS_CACHE_DIR
-    global EPHEMERAL_DIR
-    global MUTABLE_CONFIG
-    global MACHINES_DIR
-    global USER_MODULES_DIR
-    global USER_ARTIFACTS_DIR
-
-    CACHE_DIR = cache_dir
+class Config(object):
+    PROJECT_DIR = join(dirname(dirname(dirname(realpath(__file__)))))
+    INSTALL_DIR = '/usr/etc/'
+    RAPTIFORMICA_DIR = join(INSTALL_DIR, 'raptiformica')
+    CONSUL_WEB_UI_DIR = join(INSTALL_DIR, 'consul_web_ui')
+    CACHE_DIR = ".raptiformica.d"
     ABS_CACHE_DIR = join(expanduser("~"), CACHE_DIR)
     EPHEMERAL_DIR = join(ABS_CACHE_DIR, 'var')
-    MUTABLE_CONFIG = join(ABS_CACHE_DIR, 'mutable_config.json')
+    SCRIPTS_DIR = join(PROJECT_DIR, 'scripts')
     MACHINES_DIR = join(EPHEMERAL_DIR, 'machines')
+    BASE_CONFIG = join(PROJECT_DIR, '.base_config.json')
+    MUTABLE_CONFIG = join(ABS_CACHE_DIR, 'mutable_config.json')
+    CONFIG_CACHE_LOCK = '/tmp/raptiformica_config_cache.lock'
+    MODULES_DIR = join(PROJECT_DIR, 'modules')
     USER_MODULES_DIR = join(ABS_CACHE_DIR, 'modules')
     USER_ARTIFACTS_DIR = join(ABS_CACHE_DIR, 'artifacts')
+    KEY_VALUE_ENDPOINT = 'http://localhost:8500/v1/kv'
+    KEY_VALUE_TIMEOUT = 1  # How long to wait for a config retrieval
+    KEY_VALUE_PATH = 'raptiformica'
+    CJDNS_DEFAULT_PORT = 4863
+    MACHINE_ARCH = uname()[4]
+
+    def set_cache_dir(self, cache_dir):
+        """
+        Update the settings relative cache dir during runtime
+        :param str cache_dir: The cache dir to set
+        :return None:
+        """
+        self.CACHE_DIR = cache_dir
+        self.ABS_CACHE_DIR = join(expanduser("~"), self.CACHE_DIR)
+        self.EPHEMERAL_DIR = join(self.ABS_CACHE_DIR, 'var')
+        self.MUTABLE_CONFIG = join(self.ABS_CACHE_DIR, 'mutable_config.json')
+        self.MACHINES_DIR = join(self.EPHEMERAL_DIR, 'machines')
+        self.USER_MODULES_DIR = join(self.ABS_CACHE_DIR, 'modules')
+        self.USER_ARTIFACTS_DIR = join(self.ABS_CACHE_DIR, 'artifacts')
+
+config = Config()
+
+
+def conf():
+    """
+    Get the global Config object
+    :return obj config: The config object
+    """
+    global config
+    return config

--- a/raptiformica/settings/hooks.py
+++ b/raptiformica/settings/hooks.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config
 from raptiformica.settings.types import get_first_platform_type
 
@@ -12,7 +12,7 @@ def collect_hooks(hook_name, platform_type=None):
     """
     platform_type = platform_type or get_first_platform_type()
     config = get_config()
-    platform = config[KEY_VALUE_PATH]['platform'][platform_type]
+    platform = config[conf().KEY_VALUE_PATH]['platform'][platform_type]
     hooks = platform.get('hooks', {}).get(hook_name, {})
     return [{k: hook.get(k, '/bin/true') for k in ('predicate', 'command')}
             for hook in hooks.values()]

--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -10,7 +10,7 @@ from logging import getLogger
 from shutil import rmtree
 from consul_kv import Connection, map_dictionary, dictionary_map
 from consul_kv.utils import dict_merge
-from raptiformica.settings import KEY_VALUE_ENDPOINT, KEY_VALUE_PATH, KEY_VALUE_TIMEOUT
+from raptiformica.settings import conf
 
 from raptiformica.utils import load_json, write_json, list_all_files_with_extension_in_directory, ensure_directory
 import raptiformica.distributed.proxy
@@ -18,8 +18,8 @@ import raptiformica.distributed.proxy
 log = getLogger(__name__)
 
 consul_conn = Connection(
-    endpoint=KEY_VALUE_ENDPOINT,
-    timeout=KEY_VALUE_TIMEOUT
+    endpoint=conf().KEY_VALUE_ENDPOINT,
+    timeout=conf().KEY_VALUE_TIMEOUT
 )
 
 API_EXCEPTIONS = (HTTPError, HTTPException, URLError,
@@ -35,13 +35,12 @@ def config_cache_lock():
     :yield None
     :return None:
     """
-    from raptiformica.settings import CONFIG_CACHE_LOCK
-    with open(CONFIG_CACHE_LOCK, 'w+') as lock:
+    with open(conf().CONFIG_CACHE_LOCK, 'w+') as lock:
         try:
             log.debug(
                 "Getting config cache lock. "
                 "If this blocks forever, try deleting file "
-                "{} and restart the process.".format(CONFIG_CACHE_LOCK)
+                "{} and restart the process.".format(conf().CONFIG_CACHE_LOCK)
             )
             flock(lock, LOCK_EX)  # Blocks until lock becomes available
             yield
@@ -57,8 +56,7 @@ def write_config_mapping(config, config_file):
     :param str config_file: The mutable config file
     :return None:
     """
-    from raptiformica.settings import ABS_CACHE_DIR
-    ensure_directory(ABS_CACHE_DIR)
+    ensure_directory(conf().ABS_CACHE_DIR)
     # Lock the config cache file so two processes can't
     # write to the file at the same time and corrupt the json
     with config_cache_lock():
@@ -71,8 +69,7 @@ def load_module_config(modules_dir=None):
     :param str modules_dir: path to look for .json config files in
     :return list configs: list of parsed configs
     """
-    from raptiformica.settings import MODULES_DIR
-    modules_dir = modules_dir or MODULES_DIR
+    modules_dir = modules_dir or conf().MODULES_DIR
     file_names = list_all_files_with_extension_in_directory(
         modules_dir, 'json'
     )
@@ -99,8 +96,7 @@ def load_module_configs(module_dirs=None):
     :param iterable module_dirs: directories to look for module configs in
     :return list configs: list of parsed configs
     """
-    from raptiformica.settings import MODULES_DIR, USER_MODULES_DIR
-    module_dirs = module_dirs or (MODULES_DIR, USER_MODULES_DIR)
+    module_dirs = module_dirs or (conf().MODULES_DIR, conf().USER_MODULES_DIR)
     return chain.from_iterable(
         map(load_module_config, module_dirs)
     )
@@ -149,7 +145,7 @@ def download_config_mapping():
         "from the distributed key value store"
     )
     mapping = try_config_request(
-        lambda: consul_conn.get_mapping(KEY_VALUE_PATH)
+        lambda: consul_conn.get_mapping(conf().KEY_VALUE_PATH)
     )
     if not mapping:
         raise ValueError(
@@ -165,11 +161,10 @@ def on_disk_mapping(module_dirs=None):
     :param iterable module_dirs: directories to look for module configs in
     :return dict mapping: retrieved key value mapping with config data
     """
-    from raptiformica.settings import MODULES_DIR, USER_MODULES_DIR
-    module_dirs = module_dirs or (MODULES_DIR, USER_MODULES_DIR)
+    module_dirs = module_dirs or (conf().MODULES_DIR, conf().USER_MODULES_DIR)
     configs = load_module_configs(module_dirs=module_dirs)
     return {
-        join(KEY_VALUE_PATH, k): v for k, v in
+        join(conf().KEY_VALUE_PATH, k): v for k, v in
         reduce(dict_merge, map(map_dictionary, configs), dict()).items()
     }
 
@@ -206,7 +201,7 @@ def try_delete_config(key, recurse=False):
     # never be synced back to the distributed k v store but
     # should instead be fixed by some form of eventual consistency
     try:
-        path = join(KEY_VALUE_ENDPOINT, key)
+        path = join(conf().KEY_VALUE_ENDPOINT, key)
         consul_conn.delete(path, recurse=recurse)
         sync_shared_config_mapping()
     except URLError:
@@ -259,13 +254,12 @@ def cache_config_mapping(mapping):
     :param dict mapping: the cached k v mapping
     :return None:
     """
-    from raptiformica.settings import MUTABLE_CONFIG
     if not mapping:
         raise RuntimeError(
             "Passed key value mapping was null. "
             "Refusing to cache empty mapping!"
         )
-    write_config_mapping(mapping, MUTABLE_CONFIG)
+    write_config_mapping(mapping, conf().MUTABLE_CONFIG)
 
 
 def cached_config_mapping():
@@ -276,9 +270,8 @@ def cached_config_mapping():
     truncated json because another process could be updating the cache.
     :return dict mapping: the k v config mapping
     """
-    from raptiformica.settings import MUTABLE_CONFIG
     with config_cache_lock():
-        return load_json(MUTABLE_CONFIG)
+        return load_json(conf().MUTABLE_CONFIG)
 
 
 def get_local_config_mapping():
@@ -300,10 +293,9 @@ def purge_local_config_mapping():
     Remove the local config mapping if it exists
     :return None:
     """
-    from raptiformica.settings import MUTABLE_CONFIG
     log.info("Puring locally cached config")
     with suppress(FileNotFoundError):
-        remove(MUTABLE_CONFIG)
+        remove(conf().MUTABLE_CONFIG)
 
 
 def purge_config(purge_artifacts=False, purge_modules=False):
@@ -313,14 +305,13 @@ def purge_config(purge_artifacts=False, purge_modules=False):
     :param bool purge_modules: Remove all installed modules
     :return None:
     """
-    from raptiformica.settings import USER_ARTIFACTS_DIR, USER_MODULES_DIR
     purge_local_config_mapping()
     if purge_artifacts:
         log.info("Purging cached artifacts")
-        rmtree(USER_ARTIFACTS_DIR, ignore_errors=True)
+        rmtree(conf().USER_ARTIFACTS_DIR, ignore_errors=True)
     if purge_modules:
         log.info("Purging user modules")
-        rmtree(USER_MODULES_DIR, ignore_errors=True)
+        rmtree(conf().USER_MODULES_DIR, ignore_errors=True)
 
 
 def get_config_mapping():

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -4,7 +4,7 @@ from logging import getLogger
 
 from raptiformica.distributed.events import send_reload_meshnet
 from raptiformica.distributed.ping import find_host_that_can_ping
-from raptiformica.settings import CJDNS_DEFAULT_PORT, KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config_mapping, try_update_config_mapping
 from raptiformica.shell import cjdns
 from raptiformica.shell.raptiformica import inject
@@ -21,7 +21,7 @@ def ensure_shared_secret(service):
     """
     mapping = get_config_mapping()
     shared_secret_path = "{}/meshnet/{}/password".format(
-        KEY_VALUE_PATH, service
+        conf().KEY_VALUE_PATH, service
     )
     if not mapping.get(shared_secret_path):
         log.info("Generating new {} secret".format(service))
@@ -64,7 +64,7 @@ def update_neighbours_config(host, port=22, uuid=None):
 
     neighbour_entry = {
         'host': host,
-        'cjdns_port': CJDNS_DEFAULT_PORT,
+        'cjdns_port': conf().CJDNS_DEFAULT_PORT,
         'cjdns_public_key': cjdns_public_key,
         'cjdns_ipv6_address': cjdns_ipv6_address,
         # todo: get this port dynamically from the cjdroute.conf
@@ -74,7 +74,7 @@ def update_neighbours_config(host, port=22, uuid=None):
         neighbour_entry['uuid'] = uuid
 
     neighbour_path = "{}/meshnet/neighbours/{}/".format(
-        KEY_VALUE_PATH, cjdns_public_key
+        conf().KEY_VALUE_PATH, cjdns_public_key
     )
     neighbour_mapping = {
         join(neighbour_path, k): v for k, v in neighbour_entry.items()

--- a/raptiformica/settings/types.py
+++ b/raptiformica/settings/types.py
@@ -1,7 +1,7 @@
 from functools import partial
 from logging import getLogger
 
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import get_config
 from raptiformica.shell.types import check_type_available
 
@@ -15,7 +15,7 @@ def list_types_from_config(item):
     :return dict_keys types: list of all the types for the item like ['headless, 'workstation']
     """
     config = get_config()
-    return config[KEY_VALUE_PATH][item].keys()
+    return config[conf().KEY_VALUE_PATH][item].keys()
 
 
 def get_available_types_for_item(item):
@@ -99,7 +99,7 @@ def retrieve_compute_type_config_for_server_type(server_type=None, compute_type=
     compute_type = compute_type or get_first_compute_type()
     config = get_config()
     try:
-        return config[KEY_VALUE_PATH]['compute'][compute_type][server_type]
+        return config[conf().KEY_VALUE_PATH]['compute'][compute_type][server_type]
     except KeyError:
         raise RuntimeError(
             "This compute type has no implementation "

--- a/raptiformica/shell/cjdns.py
+++ b/raptiformica/shell/cjdns.py
@@ -2,7 +2,7 @@ from os import path
 from logging import getLogger
 from shlex import quote
 
-from raptiformica.settings import INSTALL_DIR, RAPTIFORMICA_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import raise_failure_factory, \
     run_critical_unbuffered_command_print_ready, run_command_print_ready, \
     run_multiple_labeled_commands
@@ -100,8 +100,10 @@ def cjdns_setup(host=None, port=22):
     :return int exit_code: exit code of the configured bootstrap command
     """
     log.info("Build, configure and install CJDNS")
-    cjdns_checkout_directory = path.join(INSTALL_DIR, 'cjdns')
-    setup_script = path.join(RAPTIFORMICA_DIR, 'resources/setup_cjdns.sh')
+    cjdns_checkout_directory = path.join(conf().INSTALL_DIR, 'cjdns')
+    setup_script = path.join(
+        conf().RAPTIFORMICA_DIR, 'resources/setup_cjdns.sh'
+    )
     cjdns_setup_command = 'cd {}; {}'.format(
         quote(cjdns_checkout_directory), setup_script,
     )

--- a/raptiformica/shell/compute.py
+++ b/raptiformica/shell/compute.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from os import path
 from uuid import uuid4
 
-from raptiformica.settings import EPHEMERAL_DIR, MACHINES_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import log_success_factory, raise_failure_factory, \
     run_command_print_ready_in_directory_factory, run_command_in_directory_factory
 from raptiformica.shell.git import clone_source
@@ -18,9 +18,10 @@ def ensure_new_compute_checkout_directory_exists(server_type, compute_type):
     :param str compute_type: name of the compute type
     :return str server_type_directory: directory for the server type of the compute type
     """
-    compute_type_directory = path.join(MACHINES_DIR, compute_type)
+    compute_type_directory = path.join(conf().MACHINES_DIR, compute_type)
     server_type_directory = path.join(compute_type_directory, server_type)
-    directories = EPHEMERAL_DIR, MACHINES_DIR, compute_type_directory, server_type_directory
+    directories = conf().EPHEMERAL_DIR, conf().MACHINES_DIR, \
+        compute_type_directory, server_type_directory
     for directory in directories:
         ensure_directory(directory)
     return server_type_directory

--- a/raptiformica/shell/config.py
+++ b/raptiformica/shell/config.py
@@ -2,7 +2,7 @@ from os import path
 from logging import getLogger
 from shlex import quote
 
-from raptiformica.settings import INSTALL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import log_failure_factory, log_success_factory, run_command_print_ready
 
 log = getLogger(__name__)
@@ -18,7 +18,7 @@ def run_resource_command(command, name, host, port=22):
     :return int exit_code: exit code of the configured bootstrap command
     """
     log.info("Running resource command: {}".format(command))
-    provisioning_directory = path.join(INSTALL_DIR, name)
+    provisioning_directory = path.join(conf().INSTALL_DIR, name)
     configured_resource_command = "cd {}; {}".format(
         quote(provisioning_directory), command
     )

--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from os import path
 from logging import getLogger
 
-from raptiformica.settings import RAPTIFORMICA_DIR, CONSUL_WEB_UI_DIR, MACHINE_ARCH
+from raptiformica.settings import conf
 from raptiformica.shell.execute import run_critical_unbuffered_command_print_ready, \
     run_multiple_labeled_commands
 from raptiformica.shell.unzip import unzip
@@ -16,7 +16,7 @@ CONSUL_ARCHES = defaultdict(
     x86_64='https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip',
     armv71='https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_arm.zip'
 )
-CONSUL_RELEASE = CONSUL_ARCHES[MACHINE_ARCH]
+CONSUL_RELEASE = CONSUL_ARCHES[conf().MACHINE_ARCH]
 CONSUL_WEB_UI_RELEASE = 'https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_web_ui.zip'
 
 
@@ -82,10 +82,13 @@ def unzip_consul_web_ui(host=None, port=22):
     :param int port: port to use to connect to the remote machine over ssh
     :return None:
     """
-    log.info("Making sure the web_ui is placed in {}".format(CONSUL_WEB_UI_DIR))
+    log.info(
+        "Making sure the web_ui is placed in "
+        "{}".format(conf().CONSUL_WEB_UI_DIR)
+    )
     unzip(
         zip_file=CONSUL_WEB_UI_RELEASE.split('/')[-1],
-        unpack_dir=CONSUL_WEB_UI_DIR,
+        unpack_dir=conf().CONSUL_WEB_UI_DIR,
         host=host, port=port,
         failure_message="Failed to unpack the consul web ui"
     )
@@ -110,7 +113,9 @@ def consul_setup(host=None, port=22):
     :return int exit_code: exit code of the configured bootstrap command
     """
     log.info("Build, configure and install CJDNS")
-    setup_script = path.join(RAPTIFORMICA_DIR, 'resources/setup_consul.sh')
+    setup_script = path.join(
+        conf().RAPTIFORMICA_DIR, 'resources/setup_consul.sh'
+    )
     cjdns_setup_command = [setup_script]
     exit_code, _, _ = run_critical_unbuffered_command_print_ready(
         cjdns_setup_command, host=host, port=port,

--- a/raptiformica/shell/execute.py
+++ b/raptiformica/shell/execute.py
@@ -5,7 +5,7 @@ from subprocess import Popen, PIPE
 from logging import getLogger
 from sys import stdout
 
-from raptiformica.settings import CACHE_DIR
+from raptiformica.settings import conf
 
 log = getLogger(__name__)
 
@@ -70,7 +70,7 @@ def execute_process(command, buffered=True, shell=False):
     """
     log.debug("Running command: {}".format(command))
     env = dict(**environ)
-    env['RAPTIFORMICA_CACHE_DIR'] = CACHE_DIR
+    env['RAPTIFORMICA_CACHE_DIR'] = conf().CACHE_DIR
     process = Popen(
         command, stdout=PIPE,
         universal_newlines=buffered,

--- a/raptiformica/shell/git.py
+++ b/raptiformica/shell/git.py
@@ -1,11 +1,10 @@
 from functools import partial
 from logging import getLogger
 from shlex import quote
-
 from functools import reduce
 from os.path import join
 
-from raptiformica.settings import INSTALL_DIR, CACHE_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import run_command_print_ready, \
     log_failure_factory, run_command
 from raptiformica.utils import ensure_directory
@@ -139,7 +138,7 @@ def ensure_latest_source_success_factory(provisioning_directory, host=None, port
     return ensure_latest_source_success
 
 
-def ensure_latest_source(source, name, destination=INSTALL_DIR, host=None, port=22):
+def ensure_latest_source(source, name, destination=None, host=None, port=22):
     """
     Ensure a repository is checked out and the latest version in the name directory
     in the INSTALL DIR on the specified machine
@@ -153,6 +152,7 @@ def ensure_latest_source(source, name, destination=INSTALL_DIR, host=None, port=
     1 when there already was a checkout
     """
     log.info("Ensuring latest source for {} from {}".format(name, source))
+    destination = destination or conf().INSTALL_DIR
     provisioning_directory = join(destination, name)
     test_directory_exists_command = ['test', '-d', provisioning_directory]
 
@@ -168,7 +168,7 @@ def ensure_latest_source(source, name, destination=INSTALL_DIR, host=None, port=
     return exit_code
 
 
-def ensure_latest_source_from_artifacts(source, name, destination=INSTALL_DIR, host=None, port=22):
+def ensure_latest_source_from_artifacts(source, name, destination=None, host=None, port=22):
     """
     Ensure a repository is checked out and the latest version in the name directory
     in the INSTALL DIR on the specified machine. Caches the repository in artifacts
@@ -183,8 +183,9 @@ def ensure_latest_source_from_artifacts(source, name, destination=INSTALL_DIR, h
     1 when there already was a checkout
     """
     repositories_directory = reduce(
-        join, (CACHE_DIR, 'artifacts', 'repositories')
+        join, (conf().CACHE_DIR, 'artifacts', 'repositories')
     )
+    destination = destination or conf().INSTALL_DIR
     ensure_directory(repositories_directory)
     source_dir = join(repositories_directory, name)
     cached_repo = 'file:///root/{}'.format(source_dir)

--- a/raptiformica/shell/hooks.py
+++ b/raptiformica/shell/hooks.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from raptiformica.settings import RAPTIFORMICA_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.hooks import collect_hooks
 from raptiformica.settings.types import get_first_platform_type
 from raptiformica.shell.execute import log_failure_factory, run_command_in_directory_factory
@@ -18,12 +18,12 @@ def fire_hook(hook):
     """
     log.debug("Firing hook..")
     run_predicate_print_ready = run_command_in_directory_factory(
-        RAPTIFORMICA_DIR, hook['predicate']
+        conf().RAPTIFORMICA_DIR, hook['predicate']
     )
     exit_code, _, _ = run_predicate_print_ready()
     if exit_code == 0:
         run_command_in_directory_partial = run_command_in_directory_factory(
-            RAPTIFORMICA_DIR, hook['command']
+            conf().RAPTIFORMICA_DIR, hook['command']
         )
         run_command_in_directory_partial(
             buffered=False,

--- a/raptiformica/shell/raptiformica.py
+++ b/raptiformica/shell/raptiformica.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from shlex import quote
 
-from raptiformica.settings import RAPTIFORMICA_DIR, CACHE_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import raise_failure_factory, run_command_remotely, run_command_print_ready
 
 log = getLogger(__name__)
@@ -16,7 +16,7 @@ def create_remote_raptiformica_cache(host, port=22):
     """
     log.info("Ensuring remote raptiformica cache directory")
     exit_code, _, _ = run_command_remotely(
-        ["mkdir", "-p", "$HOME/{}".format(CACHE_DIR)],
+        ["mkdir", "-p", "$HOME/{}".format(conf().CACHE_DIR)],
         host, port=port, buffered=False
     )
     return exit_code
@@ -34,7 +34,7 @@ def run_raptiformica_command(command_as_string, host, port=22):
              "remote host: {}".format(command_as_string))
     exit_code, _, _ = run_command_print_ready(
         ['sh', '-c', '"cd {}; {}"'.format(
-            RAPTIFORMICA_DIR, command_as_string
+            conf().RAPTIFORMICA_DIR, command_as_string
         )],
         host=host, port=port,
         failure_callback=raise_failure_factory(

--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from os.path import isdir, join
 
-from raptiformica.settings import PROJECT_DIR, INSTALL_DIR, ABS_CACHE_DIR, CACHE_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory, log_success_factory
 from raptiformica.shell.raptiformica import create_remote_raptiformica_cache
 
@@ -82,11 +82,13 @@ def upload_self(host, port=22):
     """
     log.info("Uploading raptiformica to the remote host")
     upload_partial = partial(upload, host=host, port=port)
-    upload_project_exit_code = upload_partial(PROJECT_DIR, INSTALL_DIR)
+    upload_project_exit_code = upload_partial(
+        conf().PROJECT_DIR, conf().INSTALL_DIR
+    )
     create_cache_exit_code = create_remote_raptiformica_cache(host, port=port)
     upload_config_exit_code = upload_partial(
-        ABS_CACHE_DIR, "$HOME"
-    ) if isdir(ABS_CACHE_DIR) else 0
+        conf().ABS_CACHE_DIR, "$HOME"
+    ) if isdir(conf().ABS_CACHE_DIR) else 0
     return not any(
         (
             upload_project_exit_code,
@@ -108,6 +110,6 @@ def download_artifacts(host, port=22):
     log.info("Downloading artifacts from the remote host")
     download_partial = partial(download, host=host, port=port)
     download_artifacts_exit_code = download_partial(
-        join(CACHE_DIR, 'artifacts'), ABS_CACHE_DIR
+        join(conf().CACHE_DIR, 'artifacts'), conf().ABS_CACHE_DIR
     )
     return not download_artifacts_exit_code

--- a/raptiformica/shell/types.py
+++ b/raptiformica/shell/types.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 
 from raptiformica.settings.load import get_config_mapping
 from raptiformica.shell.execute import run_command_print_ready
@@ -44,7 +44,7 @@ def check_type_available(item, type_name):
         endswith('/available'),
         filter(
             startswith('{}/{}/{}/'.format(
-                KEY_VALUE_PATH, item, type_name
+                conf().KEY_VALUE_PATH, item, type_name
             )),
             mapped
         )

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from mock import patch, Mock
 from shutil import rmtree
 
-from raptiformica.settings import ABS_CACHE_DIR, PROJECT_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import upload_config_mapping
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory
 
@@ -20,7 +20,7 @@ class TestCase(unittest.TestCase):
 class IntegrationTestCase(TestCase):
     def run_raptiformica_command(self, parameters, buffered=False):
         raptiformica_command = "{}/bin/raptiformica {}".format(
-            PROJECT_DIR.rstrip('/'), parameters
+            conf().PROJECT_DIR.rstrip('/'), parameters
         )
         _, standard_out, standard_error = run_command_print_ready(
             raptiformica_command,
@@ -36,7 +36,7 @@ class IntegrationTestCase(TestCase):
         :return str output: The buffered output if buffered was True
         """
         raptiformica_command = "`{}/bin/raptiformica ssh --info-only` {}".format(
-            PROJECT_DIR.rstrip('/'), command_as_string
+            conf().PROJECT_DIR.rstrip('/'), command_as_string
         )
         _, standard_out, standard_error = run_command_print_ready(
             raptiformica_command,
@@ -65,7 +65,7 @@ class IntegrationTestCase(TestCase):
         )
 
     def clean_up_cache_dir(self):
-        rmtree(ABS_CACHE_DIR, ignore_errors=True)
+        rmtree(conf().ABS_CACHE_DIR, ignore_errors=True)
 
     def setUp(self):
         self.kill_all_dockers()

--- a/tests/unit/raptiformica/actions/modules/test_load_configs.py
+++ b/tests/unit/raptiformica/actions/modules/test_load_configs.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 from raptiformica.actions.modules import load_configs
-from raptiformica.settings import USER_MODULES_DIR
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -35,7 +35,7 @@ class TestLoadConfigs(TestCase):
         load_configs('vdloo/puppetfiles')
 
         self.on_disk_mapping.assert_called_once_with(
-            module_dirs=(join(USER_MODULES_DIR, 'puppetfiles'),)
+            module_dirs=(join(conf().USER_MODULES_DIR, 'puppetfiles'),)
         )
 
     def test_load_configs_logs_debug_message(self):

--- a/tests/unit/raptiformica/actions/modules/test_retrieve_module.py
+++ b/tests/unit/raptiformica/actions/modules/test_retrieve_module.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 from raptiformica.actions.modules import retrieve_module
-from raptiformica.settings import USER_MODULES_DIR
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -43,5 +43,5 @@ class TestRetrieveModule(TestCase):
 
         self.clone_source.assert_called_once_with(
             'https://github.com/vdloo/puppetfiles',
-            join(USER_MODULES_DIR, 'puppetfiles')
+            join(conf().USER_MODULES_DIR, 'puppetfiles')
         )

--- a/tests/unit/raptiformica/actions/modules/test_unload_module.py
+++ b/tests/unit/raptiformica/actions/modules/test_unload_module.py
@@ -1,6 +1,6 @@
 from os.path import join
 from raptiformica.actions.modules import unload_module
-from raptiformica.settings import USER_MODULES_DIR
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -31,7 +31,7 @@ class TestUnloadModule(TestCase):
         unload_module('vdloo/puppetfiles')
 
         self.on_disk_mapping.assert_called_once_with(
-            module_dirs=(join(USER_MODULES_DIR, 'puppetfiles'),)
+            module_dirs=(join(conf().USER_MODULES_DIR, 'puppetfiles'),)
         )
 
     def test_unload_module_removes_keys(self):
@@ -39,7 +39,7 @@ class TestUnloadModule(TestCase):
 
         self.remove_keys.assert_called_once_with(
             self.on_disk_mapping.return_value,
-            join(USER_MODULES_DIR, 'puppetfiles')
+            join(conf().USER_MODULES_DIR, 'puppetfiles')
         )
 
     def test_unload_module_refreshes_keys(self):

--- a/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
+++ b/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
@@ -1,5 +1,5 @@
 from raptiformica.actions.prune import get_neighbours_by_uuid
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -9,7 +9,7 @@ class TestGetNeighboursByUuid(TestCase):
             'raptiformica.actions.prune.get_config'
         )
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {
+            conf().KEY_VALUE_PATH: {
                 'meshnet': {
                     'neighbours': {
                         'neighbour_1.k': {
@@ -61,7 +61,7 @@ class TestGetNeighboursByUuid(TestCase):
 
     def test_get_neighbours_by_uuid_returns_empty_iterable_if_no_neighbours(self):
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {
+            conf().KEY_VALUE_PATH: {
                 'meshnet': {}
             }
         }
@@ -72,7 +72,7 @@ class TestGetNeighboursByUuid(TestCase):
 
     def test_get_neighbours_by_uuid_returns_empty_iterable_if_no_meshnet_config(self):
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {}
+            conf().KEY_VALUE_PATH: {}
         }
 
         ret = get_neighbours_by_uuid('eb442c6170694b12b277c9e88d714cf2')

--- a/tests/unit/raptiformica/actions/prune/test_list_compute_checkouts_for_server_type_of_compute_type.py
+++ b/tests/unit/raptiformica/actions/prune/test_list_compute_checkouts_for_server_type_of_compute_type.py
@@ -1,8 +1,7 @@
 from os.path import join
 
 from raptiformica.actions.prune import list_compute_checkouts_for_server_type_of_compute_type
-from raptiformica.settings import EPHEMERAL_DIR
-from raptiformica.settings import MACHINES_DIR
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -18,7 +17,8 @@ class TestListComputeCheckoutsForServerTypeOfComputeType(TestCase):
             'headless', 'docker'
         )
 
-        directories = EPHEMERAL_DIR, MACHINES_DIR, 'docker', 'headless'
+        directories = conf().EPHEMERAL_DIR, conf().MACHINES_DIR, 'docker', \
+            'headless'
         server_type_of_compute_type_directory = join(*directories)
         expected_compute_checkouts = [
             ('headless', 'docker',

--- a/tests/unit/raptiformica/cli/test_destroy.py
+++ b/tests/unit/raptiformica/cli/test_destroy.py
@@ -8,12 +8,8 @@ class TestDestroy(TestCase):
             'raptiformica.cli.parse_destroy_arguments'
         )
         self.args = self.parse_destroy_arguments.return_value
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.destroy_cluster = self.set_up_patch(
-            'raptiformica.actions.destroy.destroy_cluster'
+            'raptiformica.cli.destroy_cluster'
         )
 
     def test_destroy_parses_destroy_arguments(self):

--- a/tests/unit/raptiformica/cli/test_hook.py
+++ b/tests/unit/raptiformica/cli/test_hook.py
@@ -7,12 +7,8 @@ class TestHook(TestCase):
         self.parse_hook_arguments = self.set_up_patch(
             'raptiformica.cli.parse_hook_arguments'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.trigger_handlers = self.set_up_patch(
-            'raptiformica.actions.hook.trigger_handlers'
+            'raptiformica.cli.trigger_handlers'
         )
 
     def test_hook_parses_hook_arguments(self):

--- a/tests/unit/raptiformica/cli/test_inject.py
+++ b/tests/unit/raptiformica/cli/test_inject.py
@@ -7,18 +7,14 @@ class TestInject(TestCase):
         self.parse_inject_arguments = self.set_up_patch(
             'raptiformica.cli.parse_inject_arguments'
         )
-        # patching the original functions instead of the functions in the scope
-        # of cli.py because these are conditional imports and so the functions
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.ensure_no_consul_running = self.set_up_patch(
-            'raptiformica.actions.mesh.ensure_no_consul_running'
+            'raptiformica.cli.ensure_no_consul_running'
         )
         self.update_meshnet_config = self.set_up_patch(
-            'raptiformica.settings.meshnet.update_meshnet_config'
+            'raptiformica.cli.update_meshnet_config'
         )
         self.attempt_join_meshnet = self.set_up_patch(
-            'raptiformica.actions.mesh.attempt_join_meshnet'
+            'raptiformica.cli.attempt_join_meshnet'
         )
 
     def test_inject_parses_inject_arguments(self):

--- a/tests/unit/raptiformica/cli/test_members.py
+++ b/tests/unit/raptiformica/cli/test_members.py
@@ -8,15 +8,11 @@ class TestMembers(TestCase):
             'raptiformica.cli.parse_members_arguments'
         )
         self.parse_members_arguments.return_value.rejoin = False
-        # patching the original functions instead of the functions in the scope
-        # of cli.py because these are conditional imports and so the functions
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.attempt_join_meshnet = self.set_up_patch(
-            'raptiformica.actions.mesh.attempt_join_meshnet'
+            'raptiformica.cli.attempt_join_meshnet'
         )
         self.show_members = self.set_up_patch(
-            'raptiformica.actions.members.show_members'
+            'raptiformica.cli.show_members'
         )
 
     def test_members_parses_members_arguments(self):

--- a/tests/unit/raptiformica/cli/test_mesh.py
+++ b/tests/unit/raptiformica/cli/test_mesh.py
@@ -7,12 +7,8 @@ class TestMesh(TestCase):
         self.parse_mesh_arguments = self.set_up_patch(
             'raptiformica.cli.parse_mesh_arguments'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.mesh_machine = self.set_up_patch(
-            'raptiformica.actions.mesh.mesh_machine'
+            'raptiformica.cli.mesh_machine'
         )
 
     def test_mesh_parses_mesh_arguments(self):

--- a/tests/unit/raptiformica/cli/test_modprobe.py
+++ b/tests/unit/raptiformica/cli/test_modprobe.py
@@ -7,15 +7,11 @@ class TestModprobe(TestCase):
         self.parse_modprobe_arguments = self.set_up_patch(
             'raptiformica.cli.parse_modprobe_arguments'
         )
-        # patching the original functions instead of the functions in the scope
-        # of cli.py because these are conditional imports and so the functions
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.unload_module = self.set_up_patch(
-            'raptiformica.actions.modules.unload_module'
+            'raptiformica.cli.unload_module'
         )
         self.load_module = self.set_up_patch(
-            'raptiformica.actions.modules.load_module'
+            'raptiformica.cli.load_module'
         )
 
     def test_modprobe_parses_modprobe_arguments(self):

--- a/tests/unit/raptiformica/cli/test_package.py
+++ b/tests/unit/raptiformica/cli/test_package.py
@@ -8,12 +8,8 @@ class TestPackage(TestCase):
             'raptiformica.cli.parse_package_arguments'
         )
         self.args = self.parse_package_arguments.return_value
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.package_machine = self.set_up_patch(
-            'raptiformica.actions.package.package_machine'
+            'raptiformica.cli.package_machine'
         )
 
     def test_package_parses_package_arguments(self):

--- a/tests/unit/raptiformica/cli/test_parse_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_arguments.py
@@ -3,7 +3,7 @@ from os.path import expanduser
 from mock import Mock, call
 
 from raptiformica.cli import parse_arguments
-from raptiformica.settings import CACHE_DIR
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -11,15 +11,15 @@ class TestParseArguments(TestCase):
     def setUp(self):
         self.parser = Mock()
         self.setup_logging = self.set_up_patch('raptiformica.cli.setup_logging')
-        self.set_cache_dir = self.set_up_patch('raptiformica.cli.set_cache_dir')
+        self.conf = self.set_up_patch('raptiformica.cli.conf')
         self.set_up_patch(
-            'raptiformica.cli.environ.get', return_value=CACHE_DIR
+            'raptiformica.cli.environ.get', return_value=conf().CACHE_DIR
         )
 
     def test_parse_arguments_adds_arguments(self):
         parse_arguments(self.parser)
 
-        expected_cache_dir = CACHE_DIR
+        expected_cache_dir = conf().CACHE_DIR
         expected_calls = [
             call('--verbose', '-v', action='store_true'),
             call('--cache-dir', '-c', type=str,
@@ -67,7 +67,7 @@ class TestParseArguments(TestCase):
     def test_parse_arguments_sets_cache_dir(self):
         parse_arguments(self.parser)
 
-        self.set_cache_dir.assert_called_once_with(
+        self.conf.return_value.set_cache_dir.assert_called_once_with(
             self.parser.parse_args.return_value.cache_dir
         )
 

--- a/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
@@ -1,5 +1,5 @@
 from raptiformica.cli import parse_mesh_arguments
-from raptiformica.settings import MUTABLE_CONFIG
+from raptiformica.settings import conf
 from tests.testcase import TestCase
 
 
@@ -15,7 +15,7 @@ class TestParseMeshArguments(TestCase):
             prog='raptiformica mesh',
             description='Deploy a mesh configuration based on the {} config '
                         'file on this machine and attempt to join '
-                        'the distributed network'.format(MUTABLE_CONFIG)
+                        'the distributed network'.format(conf().MUTABLE_CONFIG)
         )
 
     def test_parse_mesh_arguments_adds_arguments(self):

--- a/tests/unit/raptiformica/cli/test_prune.py
+++ b/tests/unit/raptiformica/cli/test_prune.py
@@ -7,12 +7,8 @@ class TestPrune(TestCase):
         self.parse_prune_arguments = self.set_up_patch(
             'raptiformica.cli.parse_prune_arguments'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.prune_local_machines = self.set_up_patch(
-            'raptiformica.actions.prune.prune_local_machines'
+            'raptiformica.cli.prune_local_machines'
         )
 
     def test_prune_parses_prune_arguments(self):

--- a/tests/unit/raptiformica/cli/test_slave.py
+++ b/tests/unit/raptiformica/cli/test_slave.py
@@ -13,12 +13,8 @@ class TestSlave(TestCase):
             no_provision=False, no_assimilate=False,
             host='1.2.3.4', port=22, server_type='headless'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.slave_machine = self.set_up_patch(
-            'raptiformica.actions.slave.slave_machine'
+            'raptiformica.cli.slave_machine'
         )
 
     def test_slave_parses_slave_arguments(self):

--- a/tests/unit/raptiformica/cli/test_spawn.py
+++ b/tests/unit/raptiformica/cli/test_spawn.py
@@ -14,12 +14,8 @@ class TestSpawn(TestCase):
             server_type='headless', compute_type='vagrant',
             check_available=False
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.spawn_machine = self.set_up_patch(
-            'raptiformica.actions.spawn.spawn_machine'
+            'raptiformica.cli.spawn_machine'
         )
 
     def test_spawn_parses_spawn_arguments(self):

--- a/tests/unit/raptiformica/cli/test_ssh.py
+++ b/tests/unit/raptiformica/cli/test_ssh.py
@@ -7,12 +7,8 @@ class TestSSH(TestCase):
         self.parse_ssh_arguments = self.set_up_patch(
             'raptiformica.cli.parse_ssh_arguments'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.ssh_connect = self.set_up_patch(
-            'raptiformica.actions.ssh_connect.ssh_connect'
+            'raptiformica.cli.ssh_connect'
         )
 
     def test_ssh_parses_ssh_arguments(self):

--- a/tests/unit/raptiformica/cli/test_update.py
+++ b/tests/unit/raptiformica/cli/test_update.py
@@ -7,12 +7,8 @@ class TestUpdate(TestCase):
         self.parse_update_arguments = self.set_up_patch(
             'raptiformica.cli.parse_update_arguments'
         )
-        # patching the original function instead of the function in the scope
-        # of cli.py because this is a conditional import and so that function
-        # won't be available to patch until the function that imports it is
-        # evaluated.
         self.update_machine = self.set_up_patch(
-            'raptiformica.actions.update.update_machine'
+            'raptiformica.cli.update_machine'
         )
 
     def test_update_parses_update_arguments(self):

--- a/tests/unit/raptiformica/settings/hooks/test_collect_hooks.py
+++ b/tests/unit/raptiformica/settings/hooks/test_collect_hooks.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.hooks import collect_hooks
 from tests.testcase import TestCase
 
@@ -13,7 +13,7 @@ class TestCollectHooks(TestCase):
             'raptiformica.settings.hooks.get_config'
         )
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {
+            conf().KEY_VALUE_PATH: {
                 'platform': {
                     'default': {
                         'hooks': {

--- a/tests/unit/raptiformica/settings/load/test_cache_config.py
+++ b/tests/unit/raptiformica/settings/load/test_cache_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import MUTABLE_CONFIG
+from raptiformica.settings import conf
 from raptiformica.settings.load import cache_config_mapping
 from tests.testcase import TestCase
 
@@ -22,6 +22,6 @@ class TestCacheConfig(TestCase):
 
         self.write_config.assert_called_once_with(
             self.mapping,
-            MUTABLE_CONFIG
+            conf().MUTABLE_CONFIG
         )
 

--- a/tests/unit/raptiformica/settings/load/test_cached_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_cached_config_mapping.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import MUTABLE_CONFIG
+from raptiformica.settings import conf
 from raptiformica.settings.load import cached_config_mapping
 from tests.testcase import TestCase
 
@@ -22,7 +22,9 @@ class TestCachedConfigMapping(TestCase):
     def test_cached_config_loads_mutable_config_as_json(self):
         cached_config_mapping()
 
-        self.load_json.assert_called_once_with(MUTABLE_CONFIG)
+        self.load_json.assert_called_once_with(
+            conf().MUTABLE_CONFIG
+        )
 
     def test_cached_config_returns_parsed_mutable_config_as_json(self):
         ret = cached_config_mapping()

--- a/tests/unit/raptiformica/settings/load/test_config_cache_lock.py
+++ b/tests/unit/raptiformica/settings/load/test_config_cache_lock.py
@@ -1,7 +1,7 @@
 from mock import Mock, call
 
 from fcntl import LOCK_EX, LOCK_UN
-from raptiformica.settings import CONFIG_CACHE_LOCK
+from raptiformica.settings import conf
 from raptiformica.settings.load import config_cache_lock
 from tests.testcase import TestCase
 
@@ -17,7 +17,7 @@ class TestConfigCacheLock(TestCase):
     def test_config_cache_lock_opens_cache_config_log_with_w_plus(self):
         with config_cache_lock():
             self.open.assert_called_once_with(
-                CONFIG_CACHE_LOCK, 'w+'
+                conf().CONFIG_CACHE_LOCK, 'w+'
             )
 
     def test_config_cache_lock_flock_locks_lock_file_before_context(self):

--- a/tests/unit/raptiformica/settings/load/test_download_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_download_config_mapping.py
@@ -1,6 +1,6 @@
 from mock import ANY
 
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.load import download_config_mapping
 from tests.testcase import TestCase
 
@@ -19,7 +19,7 @@ class TestDownloadConfigMapping(TestCase):
         download_config_mapping()
 
         self.get_mapping.assert_called_once_with(
-            KEY_VALUE_PATH
+            conf().KEY_VALUE_PATH
         )
 
     def test_download_config_mapping_returns_mapping(self):

--- a/tests/unit/raptiformica/settings/load/test_load_module_configs.py
+++ b/tests/unit/raptiformica/settings/load/test_load_module_configs.py
@@ -1,6 +1,6 @@
 from mock import call
 
-from raptiformica.settings import MODULES_DIR, USER_MODULES_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import load_module_configs
 from tests.testcase import TestCase
 
@@ -16,7 +16,7 @@ class TestLoadModuleConfigs(TestCase):
         list(load_module_configs())
 
         expected_calls = map(
-            call, (MODULES_DIR, USER_MODULES_DIR)
+            call, (conf().MODULES_DIR, conf().USER_MODULES_DIR)
         )
         self.assertCountEqual(
             self.load_module_config.mock_calls, expected_calls

--- a/tests/unit/raptiformica/settings/load/test_on_disk_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_on_disk_mapping.py
@@ -1,5 +1,4 @@
-from raptiformica.settings import MODULES_DIR
-from raptiformica.settings import USER_MODULES_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import on_disk_mapping
 from tests.testcase import TestCase
 
@@ -19,7 +18,7 @@ class TestOnDiskMapping(TestCase):
         on_disk_mapping()
 
         self.load_module_configs.assert_called_once_with(
-            module_dirs=(MODULES_DIR, USER_MODULES_DIR)
+            module_dirs=(conf().MODULES_DIR, conf().USER_MODULES_DIR)
         )
 
     def test_on_disk_mapping_loads_specified_module_configs(self):

--- a/tests/unit/raptiformica/settings/load/test_purge_config.py
+++ b/tests/unit/raptiformica/settings/load/test_purge_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import USER_ARTIFACTS_DIR, USER_MODULES_DIR
+from raptiformica.settings import conf
 from raptiformica.settings.load import purge_config
 from tests.testcase import TestCase
 
@@ -26,12 +26,12 @@ class TestPurgeConfig(TestCase):
         purge_config(purge_artifacts=True)
 
         self.rmtree.assert_called_once_with(
-            USER_ARTIFACTS_DIR, ignore_errors=True
+            conf().USER_ARTIFACTS_DIR, ignore_errors=True
         )
 
     def test_purge_config_purges_modules_dir_if_specified(self):
         purge_config(purge_modules=True)
 
         self.rmtree.assert_called_once_with(
-            USER_MODULES_DIR, ignore_errors=True
+            conf().USER_MODULES_DIR, ignore_errors=True
         )

--- a/tests/unit/raptiformica/settings/load/test_purge_local_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_purge_local_config_mapping.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import MUTABLE_CONFIG
+from raptiformica.settings import conf
 from raptiformica.settings.load import purge_local_config_mapping
 from tests.testcase import TestCase
 
@@ -12,7 +12,9 @@ class TestPurgeLocalConfigMapping(TestCase):
     def test_purge_local_config_mapping_removes_mutable_config(self):
         purge_local_config_mapping()
 
-        self.remove.assert_called_once_with(MUTABLE_CONFIG)
+        self.remove.assert_called_once_with(
+            conf().MUTABLE_CONFIG
+        )
 
     def test_purge_local_config_mapping_ignores_file_not_found(self):
         self.remove.side_effect = FileNotFoundError

--- a/tests/unit/raptiformica/settings/types/test_list_types_from_config.py
+++ b/tests/unit/raptiformica/settings/types/test_list_types_from_config.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.types import list_types_from_config
 from tests.testcase import TestCase
 
@@ -9,7 +9,7 @@ class TestListTypesFromConfig(TestCase):
             'raptiformica.settings.types.get_config'
         )
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {
+            conf().KEY_VALUE_PATH: {
                 'server': {
                     'headless': {},
                     'workstation': {}

--- a/tests/unit/raptiformica/settings/types/test_retrieve_compute_type_config_for_server_type.py
+++ b/tests/unit/raptiformica/settings/types/test_retrieve_compute_type_config_for_server_type.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import KEY_VALUE_PATH
+from raptiformica.settings import conf
 from raptiformica.settings.types import retrieve_compute_type_config_for_server_type
 from tests.testcase import TestCase
 
@@ -17,7 +17,7 @@ class TestRetrieveComputeTypeConfigForServerType(TestCase):
             'raptiformica.settings.types.get_config'
         )
         self.get_config.return_value = {
-            KEY_VALUE_PATH: {
+            conf().KEY_VALUE_PATH: {
                 'compute': {
                     'vagrant': {
                         'workstation': {

--- a/tests/unit/raptiformica/shell/compute/test_ensure_new_compute_checkout_directory_exists.py
+++ b/tests/unit/raptiformica/shell/compute/test_ensure_new_compute_checkout_directory_exists.py
@@ -1,20 +1,24 @@
 from mock import call
 
-from raptiformica.settings import MACHINES_DIR, EPHEMERAL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.compute import ensure_new_compute_checkout_directory_exists
 from tests.testcase import TestCase
 
 
 class TestEnsureNewComputeCheckoutDirectoryExists(TestCase):
     def setUp(self):
-        self.path = self.set_up_patch('raptiformica.shell.compute.path')
-        self.ensure_directory = self.set_up_patch('raptiformica.shell.compute.ensure_directory')
+        self.path = self.set_up_patch(
+            'raptiformica.shell.compute.path'
+        )
+        self.ensure_directory = self.set_up_patch(
+            'raptiformica.shell.compute.ensure_directory'
+        )
 
     def test_ensure_compute_type_machines_directory_exists_joins_machines_dir_to_compute_type_and_server_type(self):
         ensure_new_compute_checkout_directory_exists('headless', 'vagrant')
 
         expected_calls = [
-            call(MACHINES_DIR, 'vagrant'),
+            call(conf().MACHINES_DIR, 'vagrant'),
             call(self.path.join.return_value, 'headless')
         ]
         self.assertCountEqual(self.path.join.mock_calls, expected_calls)
@@ -22,7 +26,7 @@ class TestEnsureNewComputeCheckoutDirectoryExists(TestCase):
     def test_ensure_compute_type_machines_directory_ensures_all_directories(self):
         ensure_new_compute_checkout_directory_exists('headless', 'vagrant')
 
-        expected_calls = map(call, (EPHEMERAL_DIR, MACHINES_DIR,
+        expected_calls = map(call, (conf().EPHEMERAL_DIR, conf().MACHINES_DIR,
                                     self.path.join.return_value,
                                     self.path.join.return_value))
         self.assertCountEqual(expected_calls, self.ensure_directory.mock_calls)

--- a/tests/unit/raptiformica/shell/consul/test_consul_setup.py
+++ b/tests/unit/raptiformica/shell/consul/test_consul_setup.py
@@ -1,6 +1,6 @@
 from os.path import join
 
-from raptiformica.settings import RAPTIFORMICA_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.consul import consul_setup
 from tests.testcase import TestCase
 
@@ -29,7 +29,7 @@ class TestConsulSetup(TestCase):
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '2222',
-            join(RAPTIFORMICA_DIR, 'resources/setup_consul.sh')
+            join(conf().RAPTIFORMICA_DIR, 'resources/setup_consul.sh')
         ]
         self.execute_process.assert_called_once_with(
             expected_command,

--- a/tests/unit/raptiformica/shell/execute/test_execute_process.py
+++ b/tests/unit/raptiformica/shell/execute/test_execute_process.py
@@ -1,6 +1,6 @@
 from subprocess import PIPE
 
-from raptiformica.settings import CACHE_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.execute import execute_process
 from tests.testcase import TestCase
 
@@ -16,7 +16,7 @@ class TestExecuteProcess(TestCase):
         )
         self.environ = {
             'some': 'env_var',
-            'RAPTIFORMICA_CACHE_DIR': CACHE_DIR
+            'RAPTIFORMICA_CACHE_DIR': conf().CACHE_DIR
         }
         self.set_up_patch('raptiformica.shell.execute.environ', self.environ)
 
@@ -31,7 +31,8 @@ class TestExecuteProcess(TestCase):
         )
 
     def test_execute_process_passes_overwritten_cache_dir_from_settings_to_env(self):
-        self.set_up_patch('raptiformica.shell.execute.CACHE_DIR', '.raptiformica.d.test')
+        configuration = self.set_up_patch('raptiformica.shell.execute.conf')
+        configuration.return_value.CACHE_DIR = '.raptiformica.d.test'
 
         execute_process(self.command_as_list)
 

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source.py
@@ -1,6 +1,6 @@
 from os.path import join
 
-from raptiformica.settings import INSTALL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.git import ensure_latest_source
 from tests.testcase import TestCase
 
@@ -77,7 +77,7 @@ class TestEnsureLatestSource(TestCase):
         )
 
         self.ensure_latest_source_success_factory.assert_called_once_with(
-            join(INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
+            join(conf().INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
         )
 
     def test_ensure_latest_source_creates_failure_callback_with_default_provisioning_directory(self):
@@ -88,7 +88,7 @@ class TestEnsureLatestSource(TestCase):
 
         self.ensure_latest_source_failure_factory.assert_called_once_with(
             "https://github.com/vdloo/puppetfiles",
-            join(INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
+            join(conf().INSTALL_DIR, 'puppetfiles'), host='1.2.3.4', port=22
         )
 
     def test_ensure_latest_source_creates_success_callback_with_specified_provisioning_directory(self):

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
@@ -1,6 +1,6 @@
 from mock import call, Mock
 
-from raptiformica.settings import INSTALL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.git import ensure_latest_source_from_artifacts
 from tests.testcase import TestCase
 
@@ -39,7 +39,7 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
             call(
                 "file:///root/.raptiformica.d/artifacts/repositories/puppetfiles",
                 "puppetfiles", host='1.2.3.4', port=22,
-                destination=INSTALL_DIR
+                destination=conf().INSTALL_DIR
             )
         )
         self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)

--- a/tests/unit/raptiformica/shell/rsync/test_download.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import PROJECT_DIR, INSTALL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.rsync import download
 from tests.testcase import TestCase
 
@@ -12,13 +12,13 @@ class TestDownload(TestCase):
         self.execute_process.return_value = self.process_output
 
     def test_download_runs_download_command(self):
-        download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+        download(conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22)
 
         expected_download_command = [
             '/usr/bin/env', 'rsync', '-q', '--force', '-avz',
             '-ignore-missing-args',  # Don't warn when downloading from self
-            'root@1.2.3.4:{}'.format(PROJECT_DIR),
-            INSTALL_DIR, '--exclude=.venv',
+            'root@1.2.3.4:{}'.format(conf().PROJECT_DIR),
+            conf().INSTALL_DIR, '--exclude=.venv',
             '--exclude=*.pyc', '-e', 'ssh -p 22 '
             '-oStrictHostKeyChecking=no '
             '-oUserKnownHostsFile=/dev/null'
@@ -34,9 +34,13 @@ class TestDownload(TestCase):
         self.execute_process.return_value = self.process_output
 
         with self.assertRaises(RuntimeError):
-            download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+            download(
+                conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22
+            )
 
     def test_download_returns_command_exit_code(self):
-        ret = download(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+        ret = download(
+            conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22
+        )
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import ABS_CACHE_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.rsync import download_artifacts
 from tests.testcase import TestCase
 
@@ -19,7 +19,7 @@ class TestDownloadArtifacts(TestCase):
 
         self.download.assert_called_once_with(
             '.raptiformica.d/artifacts',
-            ABS_CACHE_DIR,
+            conf().ABS_CACHE_DIR,
             host='1.2.3.4',
             port=2222
         )

--- a/tests/unit/raptiformica/shell/rsync/test_upload.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload.py
@@ -1,4 +1,4 @@
-from raptiformica.settings import PROJECT_DIR, INSTALL_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.rsync import upload
 from tests.testcase import TestCase
 
@@ -12,14 +12,13 @@ class TestUpload(TestCase):
         self.execute_process.return_value = self.process_output
 
     def test_upload_runs_upload_command(self):
-        upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+        upload(conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22)
 
         expected_upload_command = [
-            '/usr/bin/env', 'rsync', '-q', '--force', '-avz', PROJECT_DIR,
-            'root@1.2.3.4:{}'.format(INSTALL_DIR), '--exclude=.venv',
-            '--exclude=*.pyc', '--exclude=var', '-e',
-            'ssh -p 22 '
-            '-oStrictHostKeyChecking=no '
+            '/usr/bin/env', 'rsync', '-q', '--force', '-avz',
+            conf().PROJECT_DIR, 'root@1.2.3.4:{}'.format(conf().INSTALL_DIR),
+            '--exclude=.venv', '--exclude=*.pyc', '--exclude=var', '-e',
+            'ssh -p 22 -oStrictHostKeyChecking=no '
             '-oUserKnownHostsFile=/dev/null'
         ]
         self.execute_process.assert_called_once_with(
@@ -33,9 +32,13 @@ class TestUpload(TestCase):
         self.execute_process.return_value = self.process_output
 
         with self.assertRaises(RuntimeError):
-            upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+            upload(
+                conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22
+            )
 
     def test_upload_returns_command_exit_code(self):
-        ret = upload(PROJECT_DIR, INSTALL_DIR, '1.2.3.4', port=22)
+        ret = upload(
+            conf().PROJECT_DIR, conf().INSTALL_DIR, '1.2.3.4', port=22
+        )
 
         self.assertEqual(ret, 0)

--- a/tests/unit/raptiformica/shell/rsync/test_upload_self.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload_self.py
@@ -1,7 +1,6 @@
 from mock import call
 
-from raptiformica.settings import INSTALL_DIR, ABS_CACHE_DIR
-from raptiformica.settings import PROJECT_DIR
+from raptiformica.settings import conf
 from raptiformica.shell.rsync import upload_self
 from tests.testcase import TestCase
 
@@ -31,8 +30,9 @@ class TestUploadSelf(TestCase):
         upload_self('1.2.3.4', port=22)
 
         expected_calls = [
-            call(PROJECT_DIR, INSTALL_DIR, host='1.2.3.4', port=22),
-            call(ABS_CACHE_DIR, "$HOME", host='1.2.3.4', port=22)
+            call(conf().PROJECT_DIR, conf().INSTALL_DIR, host='1.2.3.4',
+                 port=22),
+            call(conf().ABS_CACHE_DIR, "$HOME", host='1.2.3.4', port=22)
         ]
         self.assertCountEqual(self.upload.mock_calls, expected_calls)
 


### PR DESCRIPTION
So the settings can be changed during runtime by the argparser without
having to conditionally import anything that happens after that because
the config might be cached.