### PR TITLE
add --no-after-assimilate flag

### DIFF
--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -76,13 +76,17 @@ def deploy_meshnet(host, port=22):
     mesh(host, port=port)
 
 
-def slave_machine(host, port=22, provision=True, assimilate=True, server_type=None, uuid=None):
+def slave_machine(host, port=22, provision=True, assimilate=True,
+                  after_assimilate=True, server_type=None, uuid=None):
     """
-    Provision the remote machine and optionally (default yes) assimilate it into the network.
+    Provision the remote machine and optionally (default yes) assimilate it
+    into the network.
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
+    :param bool after_assimilate: whether or not we should perform the after
+    assimilation hooks
     :param str server_type: name of the server type to provision the machine as
     :param str uuid: identifier for a local compute checkout
     :return None:
@@ -96,4 +100,5 @@ def slave_machine(host, port=22, provision=True, assimilate=True, server_type=No
     if assimilate:
         assimilate_machine(host, port=port, uuid=uuid)
         deploy_meshnet(host, port=port)
-        fire_hooks('after_assimilate')
+        if after_assimilate:
+            fire_hooks('after_assimilate')

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -65,11 +65,13 @@ def start_compute_type(server_type=None, compute_type=None):
     )
 
 
-def spawn_machine(provision=False, assimilate=False, server_type=None, compute_type=None, only_check_available=False):
+def spawn_machine(provision=False, assimilate=False, after_assimilate=False, server_type=None, compute_type=None, only_check_available=False):
     """
     Start a new instance, provision it and join it into the distributed network
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
+    :param bool after_assimilate: whether or not we should perform the after
+    assimilation hooks
     :param str server_type: name of the server type to provision the machine as
     :param str compute_type: name of the compute type to start an instance on
     :param bool only_check_available: Don't really spawn a machine, just check if this host could
@@ -91,6 +93,7 @@ def spawn_machine(provision=False, assimilate=False, server_type=None, compute_t
         slave_machine(
             host, port=port,
             assimilate=assimilate,
+            after_assimilate=after_assimilate,
             provision=provision,
             server_type=server_type,
             uuid=uuid

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -57,6 +57,8 @@ def parse_slave_arguments():
                         help='Do not run the provisioning scripts for the specified server type')
     parser.add_argument('--no-assimilate', action='store_true', default=False,
                         help='Do not join or set up the distributed network.')
+    parser.add_argument('--no-after-assimilate', action='store_true', default=False,
+                        help='Do not perform the after assimilation hooks')
     parser.add_argument('--server-type', type=str, default=get_first_server_type(),
                         choices=get_server_types(),
                         help='Specify a server type. Default is '
@@ -74,6 +76,7 @@ def slave():
         args.host,
         port=args.port,
         assimilate=not args.no_assimilate,
+        after_assimilate=not args.no_after_assimilate,
         provision=not args.no_provision,
         server_type=args.server_type
     )
@@ -121,6 +124,8 @@ def parse_spawn_arguments():
                         help='Do not run the provisioning scripts for the specified server type')
     parser.add_argument('--no-assimilate', action='store_true', default=False,
                         help='Do not join or set up the distributed network.')
+    parser.add_argument('--no-after-assimilate', action='store_true', default=False,
+                        help='Do not perform the after assimilation hooks')
     parser.add_argument('--server-type', type=str, default=get_first_server_type(),
                         choices=get_server_types(),
                         help='Specify a server type. Default is {}'.format(get_first_server_type()))
@@ -140,6 +145,7 @@ def spawn():
     args = parse_spawn_arguments()
     spawn_machine(
         assimilate=not args.no_assimilate,
+        after_assimilate=not args.no_after_assimilate,
         provision=not args.no_provision,
         server_type=args.server_type,
         compute_type=args.compute_type,

--- a/tests/unit/raptiformica/actions/slave/test_slave_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_slave_machine.py
@@ -88,3 +88,18 @@ class TestSlaveMachine(TestCase):
         slave_machine('1.2.3.4', port=2222, assimilate=False)
 
         self.assertFalse(self.deploy_meshnet.called)
+
+    def test_slave_machine_does_not_perform_after_assimilate_hooks_if_assimilate_is_false(self):
+        slave_machine('1.2.3.4', port=2222, assimilate=False)
+
+    def test_slave_machine_does_not_perform_after_assimilate_hooks_if_assimilate_is_false_and_perform_assimilate(self):
+        slave_machine('1.2.3.4', port=2222, assimilate=False, after_assimilate=True)
+
+        expected_call = call('after_assimilate')
+        self.assertNotIn(expected_call, self.fire_hooks.mock_calls)
+
+    def test_slave_machine_performs_after_assimilate_hooks_if_assimilate_and_after_assimilate(self):
+        slave_machine('1.2.3.4', port=2222, assimilate=True, after_assimilate=True)
+
+        expected_call = call('after_assimilate')
+        self.assertIn(expected_call, self.fire_hooks.mock_calls)

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -45,6 +45,7 @@ class TestSpawnMachine(TestCase):
             port=2222,
             provision=True,
             assimilate=False,
+            after_assimilate=False,
             server_type=self.get_first_server_type.return_value,
             uuid='some_uuid_1234'
         )
@@ -64,13 +65,14 @@ class TestSpawnMachine(TestCase):
 
     def test_spawn_machine_slave_machine_with_provided_server_type(self):
         spawn_machine(server_type='workstation', compute_type='docker',
-                      provision=True, assimilate=True)
+                      provision=True, assimilate=True, after_assimilate=True)
 
         self.slave_machine.assert_called_once_with(
             '127.0.0.1',
             port=2222,
             provision=True,
             assimilate=True,
+            after_assimilate=True,
             server_type='workstation',
             uuid='some_uuid_1234'
         )

--- a/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
@@ -38,6 +38,8 @@ class TestParseSlaveArguments(TestCase):
                  help='Do not run the provisioning scripts for the specified server type'),
             call('--no-assimilate', action='store_true', default=False,
                  help='Do not join or set up the distributed network.'),
+            call('--no-after-assimilate', action='store_true', default=False,
+                 help='Do not perform the after assimilation hooks'),
             call('--server-type', type=str, default=self.get_first_server_type.return_value,
                  choices=self.get_server_types.return_value,
                  help='Specify a server type. Default is {}'.format(self.get_first_server_type.return_value)),

--- a/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
@@ -45,6 +45,8 @@ class TestParseSpawnArguments(TestCase):
                  help='Do not run the provisioning scripts for the specified server type'),
             call('--no-assimilate', action='store_true', default=False,
                  help='Do not join or set up the distributed network.'),
+            call('--no-after-assimilate', action='store_true', default=False,
+                 help='Do not perform the after assimilation hooks'),
             call('--server-type', type=str, default=self.get_first_server_type.return_value,
                  choices=self.get_server_types.return_value,
                  help='Specify a server type. Default is {}'.format(

--- a/tests/unit/raptiformica/cli/test_slave.py
+++ b/tests/unit/raptiformica/cli/test_slave.py
@@ -10,7 +10,7 @@ class TestSlave(TestCase):
             'raptiformica.cli.parse_slave_arguments'
         )
         self.parse_slave_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=False,
+            no_provision=False, no_assimilate=False, no_after_assimilate=False,
             host='1.2.3.4', port=22, server_type='headless'
         )
         self.slave_machine = self.set_up_patch(
@@ -27,31 +27,47 @@ class TestSlave(TestCase):
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=True,
-            assimilate=True, server_type='headless',
+            assimilate=True, after_assimilate=True,
+            server_type='headless',
         )
 
     def test_slave_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
         self.parse_slave_arguments.return_value = Mock(
-                host='1.2.3.4', port=22, server_type='headless',
-                no_assimilate=True, no_provision=False
+            host='1.2.3.4', port=22, server_type='headless',
+            no_assimilate=True, no_after_assimilate=False, no_provision=False
         )
 
         slave()
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=True,
-            assimilate=False, server_type='headless'
+            assimilate=False, after_assimilate=True,
+            server_type='headless'
+        )
+
+    def test_slave_does_not_perform_after_assimilate_hooks_when_no_after_assimilate_is_passed(self):
+        self.parse_slave_arguments.return_value = Mock(
+            host='1.2.3.4', port=22, server_type='headless',
+            no_assimilate=False, no_after_assimilate=True, no_provision=False
+        )
+
+        slave()
+
+        self.slave_machine.assert_called_once_with(
+            '1.2.3.4', port=22, provision=True,
+            assimilate=True, after_assimilate=False,
+            server_type='headless'
         )
 
     def test_slave_does_not_provision_machine_when_no_provision_is_passed(self):
         self.parse_slave_arguments.return_value = Mock(
             host='1.2.3.4', port=22, server_type='headless',
-            no_assimilate=False, no_provision=True
+            no_assimilate=False, no_after_assimilate=False, no_provision=True
         )
 
         slave()
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=False,
-            assimilate=True, server_type='headless'
+            assimilate=True, after_assimilate=True, server_type='headless'
         )

--- a/tests/unit/raptiformica/cli/test_spawn.py
+++ b/tests/unit/raptiformica/cli/test_spawn.py
@@ -11,8 +11,8 @@ class TestSpawn(TestCase):
         )
         self.parse_spawn_arguments.return_value = Mock(
             no_provision=False, no_assimilate=False,
-            server_type='headless', compute_type='vagrant',
-            check_available=False
+            no_after_assimilate=False, server_type='headless',
+            compute_type='vagrant', check_available=False
         )
         self.spawn_machine = self.set_up_patch(
             'raptiformica.cli.spawn_machine'
@@ -27,14 +27,14 @@ class TestSpawn(TestCase):
         spawn()
 
         self.spawn_machine.assert_called_once_with(
-            provision=True, assimilate=True,
+            provision=True, assimilate=True, after_assimilate=True,
             server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
     def test_spawn_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
         self.parse_spawn_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=True,
+            no_provision=False, no_assimilate=True, no_after_assimilate=False,
             server_type='headless', compute_type='vagrant',
             check_available=False
         )
@@ -42,14 +42,29 @@ class TestSpawn(TestCase):
         spawn()
 
         self.spawn_machine.assert_called_once_with(
-            provision=True, assimilate=False,
+            provision=True, assimilate=False, after_assimilate=True,
+            server_type='headless', compute_type='vagrant',
+            only_check_available=False
+        )
+
+    def test_spawn_does_not_perform_after_assimilate_hooks_if_no_after_assimilate_is_passed(self):
+        self.parse_spawn_arguments.return_value = Mock(
+            no_provision=False, no_assimilate=False, no_after_assimilate=True,
+            server_type='headless', compute_type='vagrant',
+            check_available=False
+        )
+
+        spawn()
+
+        self.spawn_machine.assert_called_once_with(
+            provision=True, assimilate=True, after_assimilate=False,
             server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
     def test_spawn_dose_not_provision_machine_when_no_provision_is_passed(self):
         self.parse_spawn_arguments.return_value = Mock(
-            no_provision=True, no_assimilate=False,
+            no_provision=True, no_assimilate=False, no_after_assimilate=False,
             server_type='headless', compute_type='vagrant',
             check_available=False
         )
@@ -57,14 +72,14 @@ class TestSpawn(TestCase):
         spawn()
 
         self.spawn_machine.assert_called_once_with(
-            provision=False, assimilate=True,
+            provision=False, assimilate=True, after_assimilate=True,
             server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
     def test_spawn_only_checks_available_if_specified(self):
         self.parse_spawn_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=False,
+            no_provision=False, no_assimilate=False, no_after_assimilate=False,
             server_type='headless', compute_type='vagrant',
             check_available=True
         )
@@ -72,7 +87,7 @@ class TestSpawn(TestCase):
         spawn()
 
         self.spawn_machine.assert_called_once_with(
-            provision=True, assimilate=True,
+            provision=True, assimilate=True, after_assimilate=True,
             server_type='headless', compute_type='vagrant',
             only_check_available=True
         )


### PR DESCRIPTION
to skip the after assimilation hooks. by default this flag will prevent
the guest host from trying to spawn additional guests hosts if there are
less than 3 machines in the cluster.