### PR TITLE
add no after mesh flag

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -609,14 +609,16 @@ def attempt_join_meshnet():
         join_meshnet()
 
 
-def mesh_machine():
+def mesh_machine(after_mesh=True):
     """
     Configure the mesh services and attempt to join the meshnet.
     If there are 'after_mesh' hooks configured, fire those.
     Exit the process with exit code 0 if no exception occurred
     so that the remote raptiformica command caller registers
     the execution as successful.
+    :param bool after_mesh: Whether or not to perform the after_mesh hooks
     :return None:
     """
     attempt_join_meshnet()
-    fire_hooks('after_mesh')
+    if after_mesh:
+        fire_hooks('after_mesh')

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -63,21 +63,23 @@ def assimilate_machine(host, port=22, uuid=None):
     ensure_route_to_new_neighbour(host, port=port, compute_checkout_uuid=uuid)
 
 
-def deploy_meshnet(host, port=22):
+def deploy_meshnet(host, port=22, after_mesh=True):
     """
     Join the machine in the distributed network
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param bool after_mesh: Whether or not to perform the after_mesh hooks
     :return None:
     """
     log.info("Joining the machine into the distributed network")
     # uploading self again to update the meshnet config
     upload_self(host, port=port)
-    mesh(host, port=port)
+    mesh(host, port=port, after_mesh=after_mesh)
 
 
 def slave_machine(host, port=22, provision=True, assimilate=True,
-                  after_assimilate=True, server_type=None, uuid=None):
+                  after_assimilate=True, after_mesh=True, server_type=None,
+                  uuid=None):
     """
     Provision the remote machine and optionally (default yes) assimilate it
     into the network.
@@ -87,6 +89,7 @@ def slave_machine(host, port=22, provision=True, assimilate=True,
     :param bool assimilate: whether or not we should assimilate the remote machine
     :param bool after_assimilate: whether or not we should perform the after
     assimilation hooks
+    :param bool after_mesh: Whether or not to perform the after_mesh hooks
     :param str server_type: name of the server type to provision the machine as
     :param str uuid: identifier for a local compute checkout
     :return None:
@@ -99,6 +102,6 @@ def slave_machine(host, port=22, provision=True, assimilate=True,
     fire_hooks('after_slave')
     if assimilate:
         assimilate_machine(host, port=port, uuid=uuid)
-        deploy_meshnet(host, port=port)
+        deploy_meshnet(host, port=port, after_mesh=after_mesh)
         if after_assimilate:
             fire_hooks('after_assimilate')

--- a/raptiformica/actions/spawn.py
+++ b/raptiformica/actions/spawn.py
@@ -65,13 +65,16 @@ def start_compute_type(server_type=None, compute_type=None):
     )
 
 
-def spawn_machine(provision=False, assimilate=False, after_assimilate=False, server_type=None, compute_type=None, only_check_available=False):
+def spawn_machine(provision=False, assimilate=False, after_assimilate=False,
+                  after_mesh=False, server_type=None, compute_type=None,
+                  only_check_available=False):
     """
     Start a new instance, provision it and join it into the distributed network
     :param bool provision: whether or not we should assimilate the remote machine
     :param bool assimilate: whether or not we should assimilate the remote machine
     :param bool after_assimilate: whether or not we should perform the after
     assimilation hooks
+    :param bool after_mesh: Whether or not to perform the after_mesh hooks
     :param str server_type: name of the server type to provision the machine as
     :param str compute_type: name of the compute type to start an instance on
     :param bool only_check_available: Don't really spawn a machine, just check if this host could
@@ -94,6 +97,7 @@ def spawn_machine(provision=False, assimilate=False, after_assimilate=False, ser
             host, port=port,
             assimilate=assimilate,
             after_assimilate=after_assimilate,
+            after_mesh=after_mesh,
             provision=provision,
             server_type=server_type,
             uuid=uuid

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -59,6 +59,8 @@ def parse_slave_arguments():
                         help='Do not join or set up the distributed network.')
     parser.add_argument('--no-after-assimilate', action='store_true', default=False,
                         help='Do not perform the after assimilation hooks')
+    parser.add_argument('--no-after-mesh', action='store_true', default=False,
+                        help='Do not perform the after mesh hooks')
     parser.add_argument('--server-type', type=str, default=get_first_server_type(),
                         choices=get_server_types(),
                         help='Specify a server type. Default is '
@@ -77,6 +79,7 @@ def slave():
         port=args.port,
         assimilate=not args.no_assimilate,
         after_assimilate=not args.no_after_assimilate,
+        after_mesh=not args.no_after_mesh,
         provision=not args.no_provision,
         server_type=args.server_type
     )
@@ -126,6 +129,8 @@ def parse_spawn_arguments():
                         help='Do not join or set up the distributed network.')
     parser.add_argument('--no-after-assimilate', action='store_true', default=False,
                         help='Do not perform the after assimilation hooks')
+    parser.add_argument('--no-after-mesh', action='store_true', default=False,
+                        help='Do not perform the after mesh hooks')
     parser.add_argument('--server-type', type=str, default=get_first_server_type(),
                         choices=get_server_types(),
                         help='Specify a server type. Default is {}'.format(get_first_server_type()))
@@ -146,6 +151,7 @@ def spawn():
     spawn_machine(
         assimilate=not args.no_assimilate,
         after_assimilate=not args.no_after_assimilate,
+        after_mesh=not args.no_after_mesh,
         provision=not args.no_provision,
         server_type=args.server_type,
         compute_type=args.compute_type,
@@ -201,6 +207,8 @@ def parse_mesh_arguments():
                     'file on this machine and attempt to join '
                     'the distributed network'.format(conf().MUTABLE_CONFIG)
     )
+    parser.add_argument('--no-after-mesh', action='store_true', default=False,
+                        help='Do not perform the after mesh hooks')
     return parse_arguments(parser)
 
 
@@ -209,8 +217,8 @@ def mesh():
     Join this machine into the distributed network
     :return None:
     """
-    parse_mesh_arguments()
-    mesh_machine()
+    args = parse_mesh_arguments()
+    mesh_machine(after_mesh=not args.no_after_mesh)
 
 
 def parse_hook_arguments():

--- a/raptiformica/shell/raptiformica.py
+++ b/raptiformica/shell/raptiformica.py
@@ -46,7 +46,7 @@ def run_raptiformica_command(command_as_string, host, port=22):
     return exit_code
 
 
-def mesh(host, port=22):
+def mesh(host, port=22, after_mesh=True):
     """
     Run ./bin/raptiformica_mesh.py on a remote machine.
     This command uses the mutable config to configure the
@@ -54,13 +54,15 @@ def mesh(host, port=22):
     new one if there are enough machines.
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param bool after_mesh: Whether or not to perform the after_mesh hooks
     :return int exit_code: Exit code from the ./bin/raptiformica_mesh.py command
     """
     log.info("Joining the remote host into the distributed network")
     # todo: let the remote raptiformica command use the same logging level
     # as the current process
     return run_raptiformica_command(
-        "export PYTHONPATH=.; ./bin/raptiformica_mesh.py --verbose",
+        "export PYTHONPATH=.; ./bin/raptiformica_mesh.py"
+        "{}".format('' if after_mesh else ' --no-after-mesh'),
         host, port=port
     )
 

--- a/tests/unit/raptiformica/actions/mesh/test_mesh_machine.py
+++ b/tests/unit/raptiformica/actions/mesh/test_mesh_machine.py
@@ -22,3 +22,8 @@ class TestMeshMachine(TestCase):
         self.fire_hooks.assert_called_once_with(
             'after_mesh'
         )
+
+    def test_mesh_machine_does_not_fire_after_mesh_hook_if_no_after_mesh(self):
+        mesh_machine(after_mesh=False)
+
+        self.assertFalse(self.fire_hooks.called)

--- a/tests/unit/raptiformica/actions/slave/test_deploy_meshnet.py
+++ b/tests/unit/raptiformica/actions/slave/test_deploy_meshnet.py
@@ -21,4 +21,13 @@ class TestDeployMeshnet(TestCase):
     def test_deploy_meshnet_runs_raptiformica_mesh_command_on_remote_host(self):
         deploy_meshnet('1.2.3.4', port=2222)
 
-        self.mesh.assert_called_once_with('1.2.3.4', port=2222)
+        self.mesh.assert_called_once_with(
+            '1.2.3.4', port=2222, after_mesh=True
+        )
+
+    def test_deploy_meshnet_skips_after_mesh_hooks_if_specified(self):
+        deploy_meshnet('1.2.3.4', port=2222, after_mesh=False)
+
+        self.mesh.assert_called_once_with(
+            '1.2.3.4', port=2222, after_mesh=False
+        )

--- a/tests/unit/raptiformica/actions/slave/test_slave_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_slave_machine.py
@@ -82,7 +82,16 @@ class TestSlaveMachine(TestCase):
     def test_slave_machine_deploys_meshnet_if_assimilate(self):
         slave_machine('1.2.3.4', port=2222, assimilate=True)
 
-        self.deploy_meshnet.assert_called_once_with('1.2.3.4', port=2222)
+        self.deploy_meshnet.assert_called_once_with(
+            '1.2.3.4', port=2222, after_mesh=True
+        )
+
+    def test_slave_machine_does_not_perform_after_mesh_hooks_if_specified(self):
+        slave_machine('1.2.3.4', port=2222, assimilate=True, after_mesh=False)
+
+        self.deploy_meshnet.assert_called_once_with(
+            '1.2.3.4', port=2222, after_mesh=False
+        )
 
     def test_slave_machine_does_not_deploy_meshnet_if_assimilate_is_false(self):
         slave_machine('1.2.3.4', port=2222, assimilate=False)

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -46,6 +46,7 @@ class TestSpawnMachine(TestCase):
             provision=True,
             assimilate=False,
             after_assimilate=False,
+            after_mesh=False,
             server_type=self.get_first_server_type.return_value,
             uuid='some_uuid_1234'
         )
@@ -73,6 +74,23 @@ class TestSpawnMachine(TestCase):
             provision=True,
             assimilate=True,
             after_assimilate=True,
+            after_mesh=False,
+            server_type='workstation',
+            uuid='some_uuid_1234'
+        )
+
+    def test_spawn_machines_slaves_machine_and_performs_after_mesh_hooks_if_specified(self):
+        spawn_machine(server_type='workstation', compute_type='docker',
+                      provision=True, assimilate=True, after_assimilate=True,
+                      after_mesh=True)
+
+        self.slave_machine.assert_called_once_with(
+            '127.0.0.1',
+            port=2222,
+            provision=True,
+            assimilate=True,
+            after_assimilate=True,
+            after_mesh=True,
             server_type='workstation',
             uuid='some_uuid_1234'
         )

--- a/tests/unit/raptiformica/cli/test_mesh.py
+++ b/tests/unit/raptiformica/cli/test_mesh.py
@@ -1,3 +1,5 @@
+from mock import Mock
+
 from raptiformica.cli import mesh
 from tests.testcase import TestCase
 
@@ -6,6 +8,9 @@ class TestMesh(TestCase):
     def setUp(self):
         self.parse_mesh_arguments = self.set_up_patch(
             'raptiformica.cli.parse_mesh_arguments'
+        )
+        self.parse_mesh_arguments.return_value = Mock(
+            no_after_mesh=False
         )
         self.mesh_machine = self.set_up_patch(
             'raptiformica.cli.mesh_machine'
@@ -19,4 +24,17 @@ class TestMesh(TestCase):
     def test_mesh_meshes_machine(self):
         mesh()
 
-        self.mesh_machine.assert_called_once_with()
+        self.mesh_machine.assert_called_once_with(
+            after_mesh=True
+        )
+
+    def test_mesh_skips_after_mesh_hooks_if_specified(self):
+        self.parse_mesh_arguments.return_value = Mock(
+            no_after_mesh=True
+        )
+
+        mesh()
+
+        self.mesh_machine.assert_called_once_with(
+            after_mesh=False
+        )

--- a/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_mesh_arguments.py
@@ -1,3 +1,5 @@
+from mock import call
+
 from raptiformica.cli import parse_mesh_arguments
 from raptiformica.settings import conf
 from tests.testcase import TestCase
@@ -21,7 +23,16 @@ class TestParseMeshArguments(TestCase):
     def test_parse_mesh_arguments_adds_arguments(self):
         parse_mesh_arguments()
 
-        self.assertFalse(self.argument_parser.return_value.add_argument.called)
+        expected_calls = [
+            call(
+                '--no-after-mesh', action='store_true', default=False,
+                help='Do not perform the after mesh hooks'
+            )
+        ]
+        self.assertEqual(
+            self.argument_parser.return_value.add_argument.mock_calls,
+            expected_calls
+        )
 
     def test_parse_mesh_arguments_parses_arguments(self):
         parse_mesh_arguments()

--- a/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_slave_arguments.py
@@ -40,6 +40,8 @@ class TestParseSlaveArguments(TestCase):
                  help='Do not join or set up the distributed network.'),
             call('--no-after-assimilate', action='store_true', default=False,
                  help='Do not perform the after assimilation hooks'),
+            call('--no-after-mesh', action='store_true', default=False,
+                 help='Do not perform the after mesh hooks'),
             call('--server-type', type=str, default=self.get_first_server_type.return_value,
                  choices=self.get_server_types.return_value,
                  help='Specify a server type. Default is {}'.format(self.get_first_server_type.return_value)),

--- a/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_spawn_arguments.py
@@ -47,6 +47,8 @@ class TestParseSpawnArguments(TestCase):
                  help='Do not join or set up the distributed network.'),
             call('--no-after-assimilate', action='store_true', default=False,
                  help='Do not perform the after assimilation hooks'),
+            call('--no-after-mesh', action='store_true', default=False,
+                 help='Do not perform the after mesh hooks'),
             call('--server-type', type=str, default=self.get_first_server_type.return_value,
                  choices=self.get_server_types.return_value,
                  help='Specify a server type. Default is {}'.format(

--- a/tests/unit/raptiformica/cli/test_slave.py
+++ b/tests/unit/raptiformica/cli/test_slave.py
@@ -11,7 +11,8 @@ class TestSlave(TestCase):
         )
         self.parse_slave_arguments.return_value = Mock(
             no_provision=False, no_assimilate=False, no_after_assimilate=False,
-            host='1.2.3.4', port=22, server_type='headless'
+            no_after_mesh=False, host='1.2.3.4', port=22,
+            server_type='headless'
         )
         self.slave_machine = self.set_up_patch(
             'raptiformica.cli.slave_machine'
@@ -28,46 +29,49 @@ class TestSlave(TestCase):
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=True,
             assimilate=True, after_assimilate=True,
-            server_type='headless',
+            after_mesh=True, server_type='headless'
         )
 
     def test_slave_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
-        self.parse_slave_arguments.return_value = Mock(
-            host='1.2.3.4', port=22, server_type='headless',
-            no_assimilate=True, no_after_assimilate=False, no_provision=False
-        )
+        self.parse_slave_arguments.return_value.no_assimilate = True
 
         slave()
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=True,
             assimilate=False, after_assimilate=True,
-            server_type='headless'
+            after_mesh=True, server_type='headless'
         )
 
     def test_slave_does_not_perform_after_assimilate_hooks_when_no_after_assimilate_is_passed(self):
-        self.parse_slave_arguments.return_value = Mock(
-            host='1.2.3.4', port=22, server_type='headless',
-            no_assimilate=False, no_after_assimilate=True, no_provision=False
-        )
+        self.parse_slave_arguments.return_value.no_after_assimilate = True
 
         slave()
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=True,
             assimilate=True, after_assimilate=False,
-            server_type='headless'
+            after_mesh=True, server_type='headless'
+        )
+
+    def test_slave_does_not_perform_after_mesh_hooks_when_no_after_mesh_is_passed(self):
+        self.parse_slave_arguments.return_value.no_after_mesh = True
+
+        slave()
+
+        self.slave_machine.assert_called_once_with(
+            '1.2.3.4', port=22, provision=True,
+            assimilate=True, after_assimilate=True,
+            after_mesh=False, server_type='headless'
         )
 
     def test_slave_does_not_provision_machine_when_no_provision_is_passed(self):
-        self.parse_slave_arguments.return_value = Mock(
-            host='1.2.3.4', port=22, server_type='headless',
-            no_assimilate=False, no_after_assimilate=False, no_provision=True
-        )
+        self.parse_slave_arguments.return_value.no_provision = True
 
         slave()
 
         self.slave_machine.assert_called_once_with(
             '1.2.3.4', port=22, provision=False,
-            assimilate=True, after_assimilate=True, server_type='headless'
+            assimilate=True, after_assimilate=True,
+            after_mesh=True, server_type='headless'
         )

--- a/tests/unit/raptiformica/cli/test_spawn.py
+++ b/tests/unit/raptiformica/cli/test_spawn.py
@@ -11,8 +11,9 @@ class TestSpawn(TestCase):
         )
         self.parse_spawn_arguments.return_value = Mock(
             no_provision=False, no_assimilate=False,
-            no_after_assimilate=False, server_type='headless',
-            compute_type='vagrant', check_available=False
+            no_after_assimilate=False, no_after_mesh=False,
+            server_type='headless', compute_type='vagrant',
+            check_available=False
         )
         self.spawn_machine = self.set_up_patch(
             'raptiformica.cli.spawn_machine'
@@ -28,66 +29,61 @@ class TestSpawn(TestCase):
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True, after_assimilate=True,
-            server_type='headless', compute_type='vagrant',
+            after_mesh=True, server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
     def test_spawn_does_not_assimilate_machine_when_no_assimilate_is_passed(self):
-        self.parse_spawn_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=True, no_after_assimilate=False,
-            server_type='headless', compute_type='vagrant',
-            check_available=False
-        )
+        self.parse_spawn_arguments.return_value.no_assimilate = True
 
         spawn()
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=False, after_assimilate=True,
-            server_type='headless', compute_type='vagrant',
+            after_mesh=True, server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
     def test_spawn_does_not_perform_after_assimilate_hooks_if_no_after_assimilate_is_passed(self):
-        self.parse_spawn_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=False, no_after_assimilate=True,
-            server_type='headless', compute_type='vagrant',
-            check_available=False
-        )
+        self.parse_spawn_arguments.return_value.no_after_assimilate = True
 
         spawn()
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True, after_assimilate=False,
-            server_type='headless', compute_type='vagrant',
+            after_mesh=True, server_type='headless', compute_type='vagrant',
             only_check_available=False
         )
 
-    def test_spawn_dose_not_provision_machine_when_no_provision_is_passed(self):
-        self.parse_spawn_arguments.return_value = Mock(
-            no_provision=True, no_assimilate=False, no_after_assimilate=False,
-            server_type='headless', compute_type='vagrant',
-            check_available=False
-        )
-
-        spawn()
-
-        self.spawn_machine.assert_called_once_with(
-            provision=False, assimilate=True, after_assimilate=True,
-            server_type='headless', compute_type='vagrant',
-            only_check_available=False
-        )
-
-    def test_spawn_only_checks_available_if_specified(self):
-        self.parse_spawn_arguments.return_value = Mock(
-            no_provision=False, no_assimilate=False, no_after_assimilate=False,
-            server_type='headless', compute_type='vagrant',
-            check_available=True
-        )
+    def test_spawn_does_not_perform_after_mesh_hooks_if_no_after_mesh_is_passed(self):
+        self.parse_spawn_arguments.return_value.no_after_mesh = True
 
         spawn()
 
         self.spawn_machine.assert_called_once_with(
             provision=True, assimilate=True, after_assimilate=True,
-            server_type='headless', compute_type='vagrant',
+            after_mesh=False, server_type='headless', compute_type='vagrant',
+            only_check_available=False
+        )
+
+    def test_spawn_dose_not_provision_machine_when_no_provision_is_passed(self):
+        self.parse_spawn_arguments.return_value.no_provision = True
+
+        spawn()
+
+        self.spawn_machine.assert_called_once_with(
+            provision=False, assimilate=True, after_assimilate=True,
+            after_mesh=True, server_type='headless', compute_type='vagrant',
+            only_check_available=False
+        )
+
+    def test_spawn_only_checks_available_if_specified(self):
+        self.parse_spawn_arguments.return_value.check_available = True
+
+        spawn()
+
+        self.spawn_machine.assert_called_once_with(
+            provision=True, assimilate=True, after_assimilate=True,
+            after_mesh=True, server_type='headless', compute_type='vagrant',
             only_check_available=True
         )

--- a/tests/unit/raptiformica/shell/raptiformica/test_mesh.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_mesh.py
@@ -18,7 +18,15 @@ class TestMesh(TestCase):
         mesh('1.2.3.4', port=2222)
 
         self.run_raptiformica_command.assert_called_once_with(
-            'export PYTHONPATH=.; ./bin/raptiformica_mesh.py --verbose',
+            'export PYTHONPATH=.; ./bin/raptiformica_mesh.py',
+            '1.2.3.4', port=2222
+        )
+
+    def test_mesh_runs_raptiformica_command_and_skips_after_mesh_hooks_if_specified(self):
+        mesh('1.2.3.4', port=2222, after_mesh=False)
+
+        self.run_raptiformica_command.assert_called_once_with(
+            'export PYTHONPATH=.; ./bin/raptiformica_mesh.py --no-after-mesh',
             '1.2.3.4', port=2222
         )
 


### PR DESCRIPTION
to skip the after mesh hooks. by default this flag will prevent
the guest host from trying to spawn additional guests hosts if there are
less than 3 machines in the cluster. that was intended already with
[this](https://github.com/vdloo/raptiformica/pull/126) change but that
was the wrong hook.