### PR TITLE
rejoin consul members that have left

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -559,7 +559,8 @@ def not_already_known_consul_neighbour(ipv6_address):
     log.info(
         "Checking if the consul agent already knows {}".format(ipv6_address)
     )
-    check_already_known = "consul members | grep {}".format(ipv6_address)
+    check_already_known = "consul members | grep -v left | " \
+                          "grep {}".format(ipv6_address)
     return not check_nonzero_exit(check_already_known)
 
 

--- a/tests/unit/raptiformica/actions/mesh/test_not_already_known_consul_neighbour.py
+++ b/tests/unit/raptiformica/actions/mesh/test_not_already_known_consul_neighbour.py
@@ -18,7 +18,7 @@ class TestNotAlreadyKnownConsulNeighbour(TestCase):
         not_already_known_consul_neighbour('some_ipv6_address')
 
         self.check_nonzero_exit.assert_called_once_with(
-            'consul members | grep some_ipv6_address'
+            'consul members | grep -v left | grep some_ipv6_address'
         )
 
     def test_not_already_known_consul_neighbour_returns_false_if_ipv6_address_found(self):


### PR DESCRIPTION
when a rejoin is triggered always try to re-connect to left consul peers because they might be back online again.