### PR TITLE
clean up opt consul if config changed

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -465,6 +465,7 @@ def reload_consul_agent_if_necessary():
     :return None:
     """
     if consul_config_hash_outdated():
+        clean_up_old_consul()
         reload_consul_agent()
         write_consul_config_hash()
 

--- a/tests/unit/raptiformica/actions/mesh/test_reload_consul_agent_if_necessary.py
+++ b/tests/unit/raptiformica/actions/mesh/test_reload_consul_agent_if_necessary.py
@@ -7,6 +7,9 @@ class TestReloadConsulAgentIfNecessary(TestCase):
         self.consul_config_hash_outdated = self.set_up_patch(
             'raptiformica.actions.mesh.consul_config_hash_outdated'
         )
+        self.clean_up_old_consul = self.set_up_patch(
+            'raptiformica.actions.mesh.clean_up_old_consul'
+        )
         self.reload_consul_agent = self.set_up_patch(
             'raptiformica.actions.mesh.reload_consul_agent'
         )
@@ -18,6 +21,13 @@ class TestReloadConsulAgentIfNecessary(TestCase):
         reload_consul_agent_if_necessary()
 
         self.consul_config_hash_outdated.assert_called_once_with()
+
+    def test_reload_consul_agent_does_not_clean_up_old_consul_if_config_hash_still_up_to_date(self):
+        self.consul_config_hash_outdated.return_value = False
+
+        reload_consul_agent_if_necessary()
+
+        self.assertFalse(self.clean_up_old_consul.called)
 
     def test_reload_consul_agent_does_not_reload_consul_agent_if_config_hash_still_up_to_date(self):
         self.consul_config_hash_outdated.return_value = False
@@ -32,6 +42,13 @@ class TestReloadConsulAgentIfNecessary(TestCase):
         reload_consul_agent_if_necessary()
 
         self.assertFalse(self.reload_consul_agent.called)
+
+    def test_reload_consul_agent_cleans_up_old_consul_if_config_hash_is_outdated(self):
+        self.consul_config_hash_outdated.return_value = True
+
+        reload_consul_agent_if_necessary()
+
+        self.clean_up_old_consul.assert_called_once_with()
 
     def test_reload_consul_agent_reloads_consul_agent_if_config_hash_is_outdated(self):
         self.consul_config_hash_outdated.return_value = True


### PR DESCRIPTION
The `/opt/consul/serf/local.keyring` file is not properly updated after the config changes (even if a new cluster is bootstrapped). This causes the agent to be unable to decipher incoming messages.

Attempting to join the updated agent:
```
root@750a8ac8b210:/usr/etc/raptiformica# consul join [fc54:88ff:33e8:5a9e:2372:3b0b:d957:5f35]:8301
Error joining the cluster: 1 error(s) occurred:

* Failed to join fc54:88ff:33e8:5a9e:2372:3b0b:d957:5f35: EOF
```

consul agent log:
```
2017/01/15 20:43:25 [ERR] memberlist: failed to receive: No installed keys could decrypt the message from=[fc00:e8ed:7ef1:b74d:54c1:9c44:c14e:1f2f]:46710
```

When the raptiformica config changes the reload will now also throw away the entire `/opt/consul` dir to make sure any lingering keyrings are gone. This might be a bit too much and I'm not sure it is going to work, if it doesn't it should perhaps only throw away the `local.keyring` as mentioned in https://github.com/hashicorp/consul/issues/719.