### PR TITLE
block until ports are free after config change

### DIFF
--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -22,6 +22,7 @@ class Config(object):
     KEY_VALUE_TIMEOUT = 1  # How long to wait for a config retrieval
     KEY_VALUE_PATH = 'raptiformica'
     CJDNS_DEFAULT_PORT = 4863
+    CONSUL_DEFAULT_PORT = 8300
     MACHINE_ARCH = uname()[4]
 
     def set_cache_dir(self, cache_dir):

--- a/tests/unit/raptiformica/actions/mesh/test_block_until_cjdroute_port_is_free.py
+++ b/tests/unit/raptiformica/actions/mesh/test_block_until_cjdroute_port_is_free.py
@@ -1,0 +1,28 @@
+from raptiformica.actions.mesh import block_until_cjdroute_port_is_free, WAIT_FOR_CJDROUTE_PORT_TIMEOUT
+from raptiformica.settings import Config
+from tests.testcase import TestCase
+
+
+class TestBlockUntilCjdroutePortIsFree(TestCase):
+    def setUp(self):
+        self.wait = self.set_up_patch(
+            'raptiformica.actions.mesh.wait'
+        )
+        self.check_if_port_available_factory = self.set_up_patch(
+            'raptiformica.actions.mesh.check_if_port_available_factory'
+        )
+
+    def test_block_until_cjdroute_port_is_free_checks_the_default_cjdroute_port(self):
+        block_until_cjdroute_port_is_free()
+
+        self.check_if_port_available_factory.assert_called_once_with(
+            Config.CJDNS_DEFAULT_PORT
+        )
+
+    def test_block_until_cjdroute_port_is_free_polls_for_nonzero_exit_code_on_port_available(self):
+        block_until_cjdroute_port_is_free()
+
+        self.wait.assert_called_once_with(
+            self.check_if_port_available_factory.return_value,
+            timeout=WAIT_FOR_CJDROUTE_PORT_TIMEOUT
+        )

--- a/tests/unit/raptiformica/actions/mesh/test_block_until_consul_becomes_available.py
+++ b/tests/unit/raptiformica/actions/mesh/test_block_until_consul_becomes_available.py
@@ -5,7 +5,7 @@ from tests.testcase import TestCase
 
 class TestBlockUntilConsulBecomesAvailable(TestCase):
     def setUp(self):
-        self.wait =  self.set_up_patch(
+        self.wait = self.set_up_patch(
             'raptiformica.actions.mesh.wait'
         )
 

--- a/tests/unit/raptiformica/actions/mesh/test_block_until_consul_port_is_free.py
+++ b/tests/unit/raptiformica/actions/mesh/test_block_until_consul_port_is_free.py
@@ -1,0 +1,28 @@
+from raptiformica.actions.mesh import block_until_consul_port_is_free, WAIT_FOR_CONSUL_PORT_TIMEOUT
+from raptiformica.settings import Config
+from tests.testcase import TestCase
+
+
+class TestBlockUntilConsulPortIsFree(TestCase):
+    def setUp(self):
+        self.wait = self.set_up_patch(
+            'raptiformica.actions.mesh.wait'
+        )
+        self.check_if_port_available_factory = self.set_up_patch(
+            'raptiformica.actions.mesh.check_if_port_available_factory'
+        )
+
+    def test_block_until_consul_port_is_free_checks_the_default_consul_port(self):
+        block_until_consul_port_is_free()
+
+        self.check_if_port_available_factory.assert_called_once_with(
+            Config.CONSUL_DEFAULT_PORT
+        )
+
+    def test_block_until_consul_port_is_free_polls_for_nonzero_exit_code_on_port_available(self):
+        block_until_consul_port_is_free()
+
+        self.wait.assert_called_once_with(
+            self.check_if_port_available_factory.return_value,
+            timeout=WAIT_FOR_CONSUL_PORT_TIMEOUT
+        )

--- a/tests/unit/raptiformica/actions/mesh/test_block_until_tun0_becomes_available.py
+++ b/tests/unit/raptiformica/actions/mesh/test_block_until_tun0_becomes_available.py
@@ -5,7 +5,7 @@ from tests.testcase import TestCase
 
 class TestBlockUntilTun0BecomesAvailable(TestCase):
     def setUp(self):
-        self.wait =  self.set_up_patch(
+        self.wait = self.set_up_patch(
             'raptiformica.actions.mesh.wait'
         )
 

--- a/tests/unit/raptiformica/actions/mesh/test_check_if_port_available_factory.py
+++ b/tests/unit/raptiformica/actions/mesh/test_check_if_port_available_factory.py
@@ -1,0 +1,35 @@
+from random import randint
+
+from raptiformica.actions.mesh import check_if_port_available_factory
+from tests.testcase import TestCase
+
+
+class TestCheckIfPortAvailableFactory(TestCase):
+    def setUp(self):
+        self.check_nonzero_exit = self.set_up_patch(
+            'raptiformica.actions.mesh.check_nonzero_exit'
+        )
+
+    def test_check_if_port_available_factory_creates_function_that_check_if_port_is_available(self):
+        mock_port = randint(150, 65535)
+
+        check_if_port_available_factory(mock_port)()
+
+        self.check_nonzero_exit.assert_called_once_with(
+            "netstat -tuna | grep {:d} && "
+            "/bin/false || /bin/true".format(mock_port)
+        )
+
+    def test_check_if_port_available_factory_returns_true_if_port_available(self):
+        self.check_nonzero_exit.return_value = True
+
+        ret = check_if_port_available_factory(123)()
+
+        self.assertTrue(ret)
+
+    def test_check_if_port_available_factory_returns_false_if_port_not_available(self):
+        self.check_nonzero_exit.return_value = False
+
+        ret = check_if_port_available_factory(123)()
+
+        self.assertFalse(ret)

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
@@ -16,6 +16,9 @@ class TestEnsureCjdnsRouting(TestCase):
         self.stop_detached_cjdroute = self.set_up_patch(
             'raptiformica.actions.mesh.stop_detached_cjdroute'
         )
+        self.block_until_cjdroute_port_is_free = self.set_up_patch(
+            'raptiformica.actions.mesh.block_until_cjdroute_port_is_free'
+        )
         self.start_detached_cjdroute = self.set_up_patch(
             'raptiformica.actions.mesh.start_detached_cjdroute'
         )
@@ -69,6 +72,13 @@ class TestEnsureCjdnsRouting(TestCase):
 
         self.stop_detached_cjdroute.assert_called_once_with()
 
+    def test_ensure_cjdns_routing_blocks_until_cjdroute_port_is_free(self):
+        self.cjdroute_config_hash_outdated.return_value = True
+
+        ensure_cjdns_routing()
+
+        self.block_until_cjdroute_port_is_free.assert_called_once_with()
+
     def test_ensure_cjdns_routing_starts_detached_cjdroute_if_config_hash_up_to_date_and_tun0_available(self):
         self.cjdroute_config_hash_outdated.return_value = True
 
@@ -104,6 +114,14 @@ class TestEnsureCjdnsRouting(TestCase):
         ensure_cjdns_routing()
 
         self.stop_detached_cjdroute.assert_called_once_with()
+
+    def test_ensure_cjdns_routing_blocks_until_cjdroute_port_is_free_if_tun0_not_available(self):
+        self.cjdroute_config_hash_outdated.return_value = False
+        self.check_if_tun0_is_available.return_value = False
+
+        ensure_cjdns_routing()
+
+        self.block_until_cjdroute_port_is_free.assert_called_once_with()
 
     def test_ensure_cjdns_routing_starts_detached_cjdroute_if_tun0_not_available(self):
         self.cjdroute_config_hash_outdated.return_value = False
@@ -144,6 +162,14 @@ class TestEnsureCjdnsRouting(TestCase):
         ensure_cjdns_routing()
 
         self.assertFalse(self.stop_detached_cjdroute.called)
+
+    def test_ensure_cjdns_routing_does_not_block_until_cjdroute_port_is_free_if_config_hash_up_to_date_and_tun0(self):
+        self.cjdroute_config_hash_outdated.return_value = False
+        self.check_if_tun0_is_available.return_value = True
+
+        ensure_cjdns_routing()
+
+        self.assertFalse(self.block_until_cjdroute_port_is_free.called)
 
     def test_ensure_cjdns_routing_does_not_start_detached_cjdroute_if_config_hash_up_to_date_and_tun0_available(self):
         self.cjdroute_config_hash_outdated.return_value = False

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_consul_agent.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_consul_agent.py
@@ -16,6 +16,9 @@ class TestEnsureConsulAgent(TestCase):
         self.clean_up_old_consul = self.set_up_patch(
             'raptiformica.actions.mesh.clean_up_old_consul'
         )
+        self.block_until_consul_port_is_free = self.set_up_patch(
+            'raptiformica.actions.mesh.block_until_consul_port_is_free'
+        )
         self.start_detached_consul_agent = self.set_up_patch(
             'raptiformica.actions.mesh.start_detached_consul_agent'
         )
@@ -50,6 +53,13 @@ class TestEnsureConsulAgent(TestCase):
 
         self.assertFalse(self.clean_up_old_consul.called)
 
+    def test_ensure_consul_agent_does_not_block_until_consul_port_is_free_if_consul_available(self):
+        self.check_if_consul_is_available.return_value = True
+
+        ensure_consul_agent()
+
+        self.assertFalse(self.block_until_consul_port_is_free.called)
+
     def test_ensure_consul_agent_does_not_start_a_new_detached_consul_agent_if_consul_already_available(self):
         self.check_if_consul_is_available.return_value = True
 
@@ -73,6 +83,13 @@ class TestEnsureConsulAgent(TestCase):
         ensure_consul_agent()
 
         self.clean_up_old_consul.assert_called_once_with()
+
+    def test_ensure_consul_agent_blocks_until_consul_port_is_free_if_not_available(self):
+        self.check_if_consul_is_available.return_value = False
+
+        ensure_consul_agent()
+
+        self.block_until_consul_port_is_free.assert_called_once_with()
 
     def test_ensure_consul_agent_starts_detached_consul_agent_if_consul_agent_not_available(self):
         self.check_if_consul_is_available.return_value = False


### PR DESCRIPTION
there is a race condition where after the services are stopped the ports
might not have been freed yet and the detached services fail to start
silently.