### PR TITLE
don't kill procs belonging to docker containers

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -209,7 +209,9 @@ def stop_detached_cjdroute():
     :return:
     """
     log.info("Stopping cjdroute in the background")
-    kill_running = "pkill -f '[c]jdroute --nobg'"
+    kill_running = "ps aux | grep [c]jdroute | awk '{print $2}' | " \
+                   "xargs --no-run-if-empty -I {} " \
+                   "sh -c \"grep -q docker /proc/{}/cgroup || kill {}\""
     run_command_print_ready(
         kill_running,
         shell=True,
@@ -415,7 +417,9 @@ def ensure_no_consul_running():
     :return None:
     """
     log.info("Stopping any running consul processes")
-    kill_running = "pkill -f '[c]onsul'"
+    kill_running = "ps aux | grep [c]onsul | awk '{print $2}' | " \
+                   "xargs --no-run-if-empty -I {} " \
+                   "sh -c \"grep -q docker /proc/{}/cgroup || kill {}\""
     run_command_print_ready(
         kill_running,
         shell=True,

--- a/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
@@ -19,11 +19,36 @@ class TestStopDetachedCjdroute(TestCase):
     def test_stop_detached_cjdroute_stops_detached_cjdroute(self):
         stop_detached_cjdroute()
 
-        expected_command = "pkill -f '[c]jdroute --nobg'"
+        expected_command = "ps aux | grep [c]jdroute | awk '{print $2}' | " \
+                           "xargs --no-run-if-empty -I {} " \
+                           "sh -c \"grep -q docker /proc/{}/cgroup || kill {}\""
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
             buffered=False
+        )
+        self.assertIn(
+            'ps aux |', expected_command,
+            'It should list all processes on the system'
+        )
+        self.assertIn(
+            '| grep [c]jdroute |', expected_command,
+            'Should find the processes with cjdroute in the name, '
+            'excluding this one'
+        )
+        self.assertIn(
+            "| awk '{print $2}' |", expected_command,
+            'Should print the PID of the processes matching the name'
+        )
+        self.assertIn(
+            "xargs --no-run-if-empty", expected_command,
+            'Should map over the found PIDs, do nothing if no matches'
+        )
+        self.assertIn(
+            "-I {} sh -c \"grep -q docker /proc/{}/cgroup || kill {}\"",
+            expected_command,
+            'Should only kill processes not in Docker containers, '
+            'those could have their own raptiformica instances running'
         )
 
     def test_stop_detached_cjdroute_does_not_raise_error_when_stopping_returned_nonzero(self):


### PR DESCRIPTION
grep those out by looking in `/proc/<PID>/cgroup`