### PR TITLE
disable cjdroute auto peer discovery

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -112,6 +112,12 @@ def configure_cjdroute_conf():
         'connectTo': neighbours,
         'bind': '0.0.0.0:{}'.format(conf().CJDNS_DEFAULT_PORT)
     }]
+    cjdroute_config['interfaces']['ETHInterface'] = [{
+        # Disable peer auto-discovery
+        'beacon': 0,
+        'bind': 'all',
+        'connectTo': {}
+    }]
     write_json(cjdroute_config, CJDROUTE_CONF_PATH)
 
 

--- a/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
@@ -67,6 +67,11 @@ class TestConfigureCjdrouteConf(TestCase):
                         }
                     },
                     'bind': '0.0.0.0:4863'
+                }],
+                'ETHInterface': [{
+                    'beacon': 0,
+                    'bind': 'all',
+                    'connectTo': {}
                 }]
             },
             'publicKey': 'yet_another_public_key.k'


### PR DESCRIPTION
don't broadcast and accept beacons to auto-peer with nodes on the same network