### PR TITLE
detect kv content before accepting proxy

### DIFF
--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -119,7 +119,9 @@ def try_config_request(func):
             # Absolute import because the distributed proxy
             # imports from settings as well
             with raptiformica.distributed.proxy.forward_any_port(
-                source_port=8500, predicate=['consul', 'members']
+                source_port=8500, predicate=[
+                    'consul', 'kv', 'get', '/raptiformica/raptiformica_api_version'
+                ]
             ):
                 return func()
         raise

--- a/tests/unit/raptiformica/settings/load/test_try_config_request.py
+++ b/tests/unit/raptiformica/settings/load/test_try_config_request.py
@@ -38,7 +38,9 @@ class TestTryConfigRequest(TestCase):
 
         self.forward_any_port.assert_called_once_with(
             source_port=8500,
-            predicate=['consul', 'members']
+            predicate=[
+                'consul', 'kv', 'get', '/raptiformica/raptiformica_api_version'
+            ]
         )
 
     def test_try_config_request_tries_callback_again_with_forwarded_port(self):


### PR DESCRIPTION
only forward the consul HTTP-API port if the remote machine has the
raptiformica_api_version in the kv store, this means there must have
been a quorum in the past and data can be queried through the API.
currently only `consul members` is tested for, which will also return
zero if the KV store can not be accessed. In that case we're better of
trying another machine in the known neighbours list or compose a new
config locally.