### PR TITLE
do not update package manager cache if too recent

### DIFF
--- a/modules/server/deploy.py
+++ b/modules/server/deploy.py
@@ -2,7 +2,7 @@
 from raptiformica.log import setup_logging
 from raptiformica.shell.consul import ensure_consul_installed
 from raptiformica.shell.cjdns import ensure_cjdns_installed
-from raptiformica.shell.package_manager import update_package_manager_cache
+from raptiformica.shell.package_manager import update_local_package_manager_cache_if_necessary
 
 
 def main():
@@ -12,7 +12,7 @@ def main():
     :return None:
     """
     setup_logging()
-    update_package_manager_cache()
+    update_local_package_manager_cache_if_necessary()
     ensure_cjdns_installed()
     ensure_consul_installed()
 

--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -15,6 +15,8 @@ class Config(object):
     BASE_CONFIG = join(PROJECT_DIR, '.base_config.json')
     MUTABLE_CONFIG = join(ABS_CACHE_DIR, 'mutable_config.json')
     CONFIG_CACHE_LOCK = '/tmp/raptiformica_config_cache.lock'
+    PACKAGE_MANGER_UPDATED = '/tmp/raptiformica_last_updated_package_manager'
+    PACKAGE_MANAGER_CACHE_OUTDATED = 600
     MODULES_DIR = join(PROJECT_DIR, 'modules')
     USER_MODULES_DIR = join(ABS_CACHE_DIR, 'modules')
     USER_ARTIFACTS_DIR = join(ABS_CACHE_DIR, 'artifacts')

--- a/raptiformica/shell/package_manager.py
+++ b/raptiformica/shell/package_manager.py
@@ -1,6 +1,10 @@
 from logging import getLogger
+from pathlib import Path
+from os.path import isfile
 
+from raptiformica.settings import conf
 from raptiformica.shell.execute import run_multiple_labeled_commands
+from raptiformica.utils import file_age_in_seconds
 
 log = getLogger(__name__)
 
@@ -24,3 +28,16 @@ def update_package_manager_cache(host=None, port=22):
         ensure_cache_updated_commands, host=host, port=port,
         failure_message="Failed to run (if {}) update package manager command"
     )
+
+
+def update_local_package_manager_cache_if_necessary():
+    """
+    Update the package manager cache if the last update was longer than the
+    specified PACKAGE_MANAGER_CACHE_OUTDATED seconds defined in the config
+    :return None:
+    """
+    outdated = conf().PACKAGE_MANAGER_CACHE_OUTDATED
+    updated = conf().PACKAGE_MANGER_UPDATED
+    if not isfile(updated) or file_age_in_seconds(updated) > outdated:
+        update_package_manager_cache()
+        Path(updated).touch()

--- a/raptiformica/utils.py
+++ b/raptiformica/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from time import time
 from copy import deepcopy
 from functools import wraps
 from itertools import chain
@@ -7,6 +8,8 @@ from os import path, makedirs, walk
 
 from logging import getLogger
 from time import sleep
+
+from os.path import getmtime
 
 log = getLogger(__name__)
 
@@ -182,3 +185,12 @@ def calculate_checksum(filename):
             file_hash.update(buf)
             buf = f.read(128)
         return file_hash.hexdigest()
+
+
+def file_age_in_seconds(filename):
+    """
+    Get the difference in seconds between now and the mtime of the file
+    :param str filename: File to get the time since last mtime update of
+    :return int seconds: Time in seconds since last mtime uptdate
+    """
+    return time() - getmtime(filename)

--- a/tests/unit/raptiformica/shell/package_manager/test_update_local_package_manager_cache_if_necessary.py
+++ b/tests/unit/raptiformica/shell/package_manager/test_update_local_package_manager_cache_if_necessary.py
@@ -1,0 +1,82 @@
+from raptiformica.settings import conf
+from raptiformica.shell.package_manager import update_local_package_manager_cache_if_necessary
+from tests.testcase import TestCase
+
+
+class TestUpdateLocalPackageManagerCacheIfNecessary(TestCase):
+    def setUp(self):
+        self.file_age_in_seconds = self.set_up_patch(
+            'raptiformica.shell.package_manager.file_age_in_seconds'
+        )
+        self.file_age_in_seconds.return_value = conf().PACKAGE_MANAGER_CACHE_OUTDATED + 1
+        self.isfile = self.set_up_patch(
+            'raptiformica.shell.package_manager.isfile'
+        )
+        self.isfile.return_value = True
+        self.update_package_manager_cache = self.set_up_patch(
+            'raptiformica.shell.package_manager.update_package_manager_cache'
+        )
+        self.path = self.set_up_patch(
+            'raptiformica.shell.package_manager.Path'
+        )
+
+    def test_update_local_package_manager_cache_if_necessary_checks_if_updated_file_exists(self):
+        update_local_package_manager_cache_if_necessary()
+
+        self.isfile.assert_called_once_with(
+            conf().PACKAGE_MANGER_UPDATED
+        )
+
+    def test_update_local_package_manager_cache_does_not_check_updated_file_age_if_no_file(self):
+        self.isfile.return_value = False
+
+        update_local_package_manager_cache_if_necessary()
+
+        self.assertFalse(self.file_age_in_seconds.called)
+
+    def test_update_local_package_manager_cache_checks_file_age_in_seconds_if_updated_file_exists(self):
+        update_local_package_manager_cache_if_necessary()
+
+        self.file_age_in_seconds.assert_called_once_with(
+            conf().PACKAGE_MANGER_UPDATED
+        )
+
+    def test_update_local_package_manager_cache_updates_package_manager_cache_if_file_too_old(self):
+        update_local_package_manager_cache_if_necessary()
+
+        self.update_package_manager_cache.assert_called_once_with()
+
+    def test_update_local_package_manager_cache_touches_the_updated_file_if_file_too_old(self):
+        update_local_package_manager_cache_if_necessary()
+
+        self.path.assert_called_once_with(conf().PACKAGE_MANGER_UPDATED)
+        self.path.return_value.touch.assert_called_once_with()
+
+    def test_update_local_package_manager_cache_updates_package_manager_cache_if_no_file_yet(self):
+        self.isfile.return_value = False
+
+        update_local_package_manager_cache_if_necessary()
+
+        self.update_package_manager_cache.assert_called_once_with()
+
+    def test_update_local_package_manager_cache_touches_the_updated_file_if_no_file_yet(self):
+        self.isfile.return_value = False
+
+        update_local_package_manager_cache_if_necessary()
+
+        self.path.assert_called_once_with(conf().PACKAGE_MANGER_UPDATED)
+        self.path.return_value.touch.assert_called_once_with()
+
+    def test_update_local_package_manager_cache_does_not_update_cache_if_cache_too_recent(self):
+        self.file_age_in_seconds.return_value -= 1
+
+        update_local_package_manager_cache_if_necessary()
+
+        self.assertFalse(self.update_package_manager_cache.called)
+
+    def test_update_local_package_manager_cache_does_not_touch_the_updated_file_if_cache_not_updated(self):
+        self.file_age_in_seconds.return_value -= 1
+
+        update_local_package_manager_cache_if_necessary()
+
+        self.assertFalse(self.path.called)

--- a/tests/unit/raptiformica/utils/test_file_age_in_seconds.py
+++ b/tests/unit/raptiformica/utils/test_file_age_in_seconds.py
@@ -1,0 +1,34 @@
+from raptiformica.utils import file_age_in_seconds
+from tests.testcase import TestCase
+
+
+class TestFileAgeInSeconds(TestCase):
+    def setUp(self):
+        self.time = self.set_up_patch(
+            'raptiformica.utils.time'
+        )
+        self.time.return_value = 12345
+        self.getmtime = self.set_up_patch(
+            'raptiformica.utils.getmtime'
+        )
+        self.getmtime.return_value = 12121
+
+    def test_file_age_in_seconds_gets_current_time(self):
+        file_age_in_seconds('/some/file')
+
+        self.time.assert_called_once_with()
+
+    def test_file_age_in_seconds_gets_mtime_of_file(self):
+        file_age_in_seconds('/some/file')
+
+        self.getmtime.assert_called_once_with(
+            '/some/file'
+        )
+
+    def test_file_age_in_seconds_returns_difference_between_current_time_and_mtime(self):
+        ret = file_age_in_seconds('/some/file')
+
+        expected_time = self.time.return_value - self.getmtime.return_value
+        self.assertEqual(
+            ret, expected_time
+        )


### PR DESCRIPTION
touch a file when the cache has been updated, if the mtime is too recent during the next update, skip the update.