### PR TITLE
restart consul when in memory keyring outdated

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_consul_keyring_in_memory_is_stale.py
+++ b/tests/unit/raptiformica/actions/mesh/test_consul_keyring_in_memory_is_stale.py
@@ -1,0 +1,46 @@
+from mock import ANY
+
+from raptiformica.actions.mesh import consul_keyring_in_memory_is_stale
+from tests.testcase import TestCase
+
+
+class TestConsulKeyringInMemoryIsStale(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch(
+            'raptiformica.actions.mesh.log'
+        )
+        self.check_nonzero_exit = self.set_up_patch(
+            'raptiformica.actions.mesh.check_nonzero_exit'
+        )
+        self.check_nonzero_exit.return_value = False
+
+    def test_consul_keyring_in_memory_is_stale_logs_checking_keyring_in_memory_message(self):
+        consul_keyring_in_memory_is_stale('the_secret')
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_consul_keyring_in_memory_is_stale_checks_if_shared_key_is_in_memory(self):
+        consul_keyring_in_memory_is_stale('the_secret')
+
+        self.check_nonzero_exit.assert_called_once_with(
+            'consul keyring --list |& grep -q the_secret'
+        )
+
+    def test_consul_keyring_in_memory_is_stale_escapes_special_characters_in_shared_secret(self):
+        consul_keyring_in_memory_is_stale('\';echo 123 $%^"')
+
+        self.check_nonzero_exit.assert_called_once_with(
+            'consul keyring --list |& grep -q \'\'"\'"\';echo 123 $%^"\''
+        )
+
+    def test_consul_keyring_in_memory_is_stale_returns_true_if_returned_nonzero(self):
+        ret = consul_keyring_in_memory_is_stale('the_secret')
+
+        self.assertTrue(ret)
+
+    def test_consul_keyring_in_memory_is_stale_returns_false_if_returned_zero(self):
+        self.check_nonzero_exit.return_value = True
+
+        ret = consul_keyring_in_memory_is_stale('the_secret')
+
+        self.assertFalse(ret)

--- a/tests/unit/raptiformica/actions/mesh/test_consul_keyring_on_disk_is_stale.py
+++ b/tests/unit/raptiformica/actions/mesh/test_consul_keyring_on_disk_is_stale.py
@@ -1,0 +1,46 @@
+from mock import ANY
+
+from raptiformica.actions.mesh import consul_keyring_on_disk_is_stale
+from tests.testcase import TestCase
+
+
+class TestConsulKeyringOnDiskIsStale(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch(
+            'raptiformica.actions.mesh.log'
+        )
+        self.check_nonzero_exit = self.set_up_patch(
+            'raptiformica.actions.mesh.check_nonzero_exit'
+        )
+        self.check_nonzero_exit.return_value = False
+
+    def test_consul_keyring_on_disk_is_stale_logs_checking_keyring_on_disk_message(self):
+        consul_keyring_on_disk_is_stale('the_secret')
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_consul_keyring_on_disk_is_stale_checks_if_shared_key_is_on_disk(self):
+        consul_keyring_on_disk_is_stale('the_secret')
+
+        self.check_nonzero_exit.assert_called_once_with(
+            'grep the_secret /opt/consul/serf/local.keyring'
+        )
+
+    def test_consul_keyring_on_disk_is_stale_escapes_special_characters_in_shared_secret(self):
+        consul_keyring_on_disk_is_stale('\';echo 123 $%^"')
+
+        self.check_nonzero_exit.assert_called_once_with(
+            'grep \'\'"\'"\';echo 123 $%^"\' /opt/consul/serf/local.keyring'
+        )
+
+    def test_consul_keyring_on_disk_is_stale_returns_true_if_returned_nonzero(self):
+        ret = consul_keyring_on_disk_is_stale('the_secret')
+
+        self.assertTrue(ret)
+
+    def test_consul_keyring_on_disk_is_stale_returns_false_if_returned_zero(self):
+        self.check_nonzero_exit.return_value = True
+
+        ret = consul_keyring_on_disk_is_stale('the_secret')
+
+        self.assertFalse(ret)


### PR DESCRIPTION
the keyring in memory can be outdated while the keyring on disk is up to
date, this can happen when restarting consul after detecting an outdated
keyring on disk fails.