### PR TITLE
randomize peer join order

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from os import remove
 from os.path import join, isfile
 from logging import getLogger
+from random import shuffle
 from shutil import rmtree
 
 from raptiformica.settings import conf
@@ -722,6 +723,7 @@ def join_consul_neighbours(mapping):
     :return None:
     """
     ipv6_addresses = get_neighbour_hosts(mapping)
+    shuffle(ipv6_addresses)
     new_ipv6_addresses = list(
         filter(not_already_known_consul_neighbour, ipv6_addresses)
     )

--- a/tests/unit/raptiformica/actions/mesh/test_join_consul_neighbours.py
+++ b/tests/unit/raptiformica/actions/mesh/test_join_consul_neighbours.py
@@ -26,6 +26,9 @@ class TestJoinConsulNeighbours(TestCase):
         self.get_neighbour_hosts = self.set_up_patch(
             'raptiformica.actions.mesh.get_neighbour_hosts'
         )
+        self.shuffle = self.set_up_patch(
+            'raptiformica.actions.mesh.shuffle'
+        )
         self.not_already_known_consul_neighbour = self.set_up_patch(
             'raptiformica.actions.mesh.not_already_known_consul_neighbour'
         )
@@ -39,6 +42,14 @@ class TestJoinConsulNeighbours(TestCase):
         join_consul_neighbours(self.mapping)
 
         self.get_neighbour_hosts.assert_called_once_with(self.mapping)
+
+    def test_join_consul_neighbours_randomizes_peer_join_order(self):
+        join_consul_neighbours(self.mapping)
+
+        self.assertCountEqual(
+            ('some_ipv6_address', 'some_other_ipv6_address'),
+            sorted(self.shuffle.call_args[0][0])
+        )
 
     def test_join_consul_neighbours_checks_each_neighbour_for_already_known(self):
         join_consul_neighbours(self.mapping)


### PR DESCRIPTION
so the first ones in the distributed key value store won't be joined first always. this has a slightly centralizing effect on the network.

![graph](https://cloud.githubusercontent.com/assets/1437341/23097126/878200ea-f62c-11e6-9d7e-184d9cbd7104.png)
