### PR TITLE
Do not compile cjdroute with seccomp on pi's

### DIFF
--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -12,7 +12,7 @@ if [ ! -f cjdroute ]; then
         cp ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/cjdroute .
     else
         echo 'compiling new cjdoute'
-        ./do
+        lsb_release -a | grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
         mkdir -p ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
         cp -f cjdroute ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
     fi


### PR DESCRIPTION
```
./do
...
Running test Seccomp_testAssertion failure [Seccomp_test.c:62] [(!"timed out")]
...
Failed to build cjdns.
Total build time: 228312ms.
```