### PR TITLE
retry configuration if failed to parse json

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -94,6 +94,7 @@ def parse_cjdns_neighbours(mapping):
     return neighbours
 
 
+@retry(attempts=2, expect=(ValueError,))
 def configure_cjdroute_conf():
     """
     Configure the cjdroute config according to the


### PR DESCRIPTION
it could be that the consul watcher was just updating this file