### PR TITLE
do not ping host from same host

### DIFF
--- a/raptiformica/distributed/ping.py
+++ b/raptiformica/distributed/ping.py
@@ -52,5 +52,11 @@ def find_host_that_can_ping(host):
     """
     log.info("Finding a host in the network that can ping {}".format(host))
     host_and_port_pairs = host_and_port_pairs_from_config()
-    _, access_host, access_host_ssh_port = try_ping(host_and_port_pairs, host)
+    neighbour_host_and_port_pairs = [
+        pair for pair in host_and_port_pairs
+        if pair[0] != host
+    ]
+    _, access_host, access_host_ssh_port = try_ping(
+        neighbour_host_and_port_pairs, host
+    )
     return access_host, access_host_ssh_port

--- a/tests/unit/raptiformica/distributed/ping/test_find_host_that_can_ping.py
+++ b/tests/unit/raptiformica/distributed/ping/test_find_host_that_can_ping.py
@@ -12,6 +12,11 @@ class TestFindHostThatCanPing(TestCase):
         self.host_and_port_pairs_from_config = self.set_up_patch(
             'raptiformica.distributed.ping.host_and_port_pairs_from_config'
         )
+        self.host_and_port_pairs_from_config.return_value = [
+            ('1.2.3.2', '22'),
+            ('1.2.3.3', '22'),
+            ('1.2.3.4', '22')
+        ]
         self.try_ping = self.set_up_patch(
             'raptiformica.distributed.ping.try_ping'
         )
@@ -29,11 +34,17 @@ class TestFindHostThatCanPing(TestCase):
 
         self.host_and_port_pairs_from_config.assert_called_once_with()
 
-    def test_find_host_that_can_ping_tries_pinging_the_host_from_the_config_neighbours(self):
+    def test_find_host_that_can_ping_tries_pinging_the_host_from_config_neighbours(self):
         find_host_that_can_ping('1.2.3.4')
 
+        expected_host_and_port_pairs = [
+            ('1.2.3.2', '22'),
+            ('1.2.3.3', '22')
+            # Does not include '1.2.3.4', we should not try to
+            # ping the host from the host we are trying to ping
+        ]
         self.try_ping.assert_called_once_with(
-            self.host_and_port_pairs_from_config.return_value,
+            expected_host_and_port_pairs,
             '1.2.3.4'
         )
 


### PR DESCRIPTION
When re-assimilating a machine into the network the public key will have
to be updated on a neighbour that can ping the machine. Currently it is
possible that the machine that needs to be updated is regarded as the
first machine that can ping the machine for which a neighbour should be
updated. Instead only all other machines should be tested for being able
to ping the re-assimilated machine.