### PR TITLE
skip bootstrap new peer if can not ssh

### DIFF
--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -142,9 +142,16 @@ def ensure_route_to_new_neighbour(
     connected_host, connected_host_port = find_host_that_can_ping(host)
     if connected_host:
         log.info("Found peer that can connect directly to the new neighbour")
-        bootstrap_host_to_neighbour(
-            host, port, connected_host, connected_host_port
-        )
+        try:
+            bootstrap_host_to_neighbour(
+                host, port, connected_host, connected_host_port
+            )
+        except RuntimeError:
+            log.debug(
+                "Failed to add new peer to the known host that can ping it. "
+                "If a quorum is already established the meshnet reload event we'll "
+                "send now should catch it. Skipping for now."
+            )
     else:
         log.info(
             "Found no neighbour that could already connect "

--- a/tests/unit/raptiformica/settings/meshnet/test_ensure_route_to_new_neighbour.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_ensure_route_to_new_neighbour.py
@@ -46,6 +46,17 @@ class TestEnsureRouteToNewNeighbour(TestCase):
             '1.2.3.4', 2222, '1.2.3.3', 22
         )
 
+    def test_ensure_route_to_new_neighbour_does_not_error_when_bootstrapping_host_to_connected_neighbour_fails(self):
+        self.bootstrap_host_to_neighbour.side_effect = RuntimeError(
+            "Permission denied, can't login over SSH"
+        )
+
+        ensure_route_to_new_neighbour('1.2.3.4', port=2222)
+
+        self.bootstrap_host_to_neighbour.assert_called_once_with(
+            '1.2.3.4', 2222, '1.2.3.3', 22
+        )
+
     def test_ensure_route_to_new_neighbour_does_not_bootstrap_host_to_neighbour_if_no_connected_neighbour(self):
         self.find_host_that_can_ping.return_value = (None, None)
 


### PR DESCRIPTION
a meshnet reload event will be sent to all connected agents, if this
step fails before a cluster is established the process will fail anyway
later. If it fails after a cluster has already been established the
reload event might still fix up the routes in time.

this situation can happen if there are two machines in the cluster with
guests with the same IPs for example. If machine 1 is spawning a docker
with IP 172.17.0.2 and machine 2 already hosts a docker with that IP and
they're both connected, a failing SSH connection from machine 2 to the
local Docker instance could previously halt the process.