### PR TITLE
cache git repos on client

### DIFF
--- a/raptiformica/shell/consul.py
+++ b/raptiformica/shell/consul.py
@@ -16,6 +16,7 @@ CONSUL_ARCHES = defaultdict(
 )
 CONSUL_RELEASE = CONSUL_ARCHES[conf().MACHINE_ARCH]
 CONSUL_WEB_UI_RELEASE = 'https://releases.hashicorp.com/consul/0.7.4/consul_0.7.4_web_ui.zip'
+CONSUL_KV_REPOSITORY = 'https://github.com/vdloo/consul-kv'
 
 
 def ensure_consul_dependencies(host=None, port=22):

--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -58,6 +58,7 @@ def upload(source, destination, host, port=22):
               '-oStrictHostKeyChecking=no '
               '-oUserKnownHostsFile=/dev/null'.format(port)
     ]
+    log.info("Uploading local {} to remote {}".format(source, destination))
     exit_code, _, _ = run_command_print_ready(
         upload_command,
         success_callback=log_success_factory(

--- a/tests/unit/raptiformica/actions/slave/test_ensure_source_on_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_ensure_source_on_machine.py
@@ -1,0 +1,148 @@
+from unittest.mock import Mock
+
+from mock import ANY, call
+
+from raptiformica.actions.slave import ensure_source_on_machine
+from tests.testcase import TestCase
+
+
+class TestEnsureSourceOnMachine(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch(
+            'raptiformica.actions.slave.log'
+        )
+        self.get_first_server_type = self.set_up_patch(
+            'raptiformica.actions.slave.get_first_server_type'
+        )
+        self.retrieve_provisioning_configs = self.set_up_patch(
+            'raptiformica.actions.slave.retrieve_provisioning_configs'
+        )
+        self.retrieve_provisioning_configs.return_value = {
+            'puppetfiles': {'source': 'file:///some/repo/to/the/puppetfiles.git'},
+            'vagrantfiles': {'source': 'https://example.com/some/repo/to/the/vagrantfiles.git'}
+        }
+        self.ensure_latest_source_from_artifacts = self.set_up_patch(
+            'raptiformica.actions.slave.ensure_latest_source_from_artifacts'
+        )
+
+    def test_ensure_source_on_machine_logs_info(self):
+        ensure_source_on_machine()
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_ensure_source_on_machine_gets_first_server_type_if_none_is_provided(self):
+        ensure_source_on_machine()
+
+        self.get_first_server_type.assert_called_once_with()
+
+    def test_ensure_source_on_machine_does_not_get_server_type_if_one_is_provided(self):
+        ensure_source_on_machine(server_type='workstation')
+
+        self.assertFalse(self.get_first_server_type.called)
+
+    def test_ensure_source_on_machine_retrieves_provisioning_configs_of_specified_server_type(self):
+        ensure_source_on_machine(server_type='workstation')
+
+        self.retrieve_provisioning_configs.assert_called_once_with(
+            'workstation'
+        )
+
+    def test_ensure_source_on_machine_retrieves_provisioning_configs_of_first_server_type_if_none_provided(self):
+        ensure_source_on_machine()
+
+        self.retrieve_provisioning_configs.assert_called_once_with(
+            self.get_first_server_type.return_value
+        )
+
+    def test_ensure_source_on_machine_ensures_latest_source_from_artifacts_for_all_provisioning_configs(self):
+        ensure_source_on_machine()
+
+        expected_calls = (
+            call(
+                'file:///some/repo/to/the/puppetfiles.git',
+                'puppetfiles', host=None, port=22,
+                only_cache=False
+            ),
+            call(
+                'https://example.com/some/repo/to/the/vagrantfiles.git',
+                'vagrantfiles', host=None, port=22,
+                only_cache=False
+            )
+        )
+        self.assertCountEqual(
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
+        )
+
+    def test_ensure_source_on_machine_ensures_latest_source_for_all_provisioning_configs_with_only_cache(self):
+        ensure_source_on_machine(only_cache=True)
+
+        expected_calls = (
+            call(
+                'file:///some/repo/to/the/puppetfiles.git',
+                'puppetfiles', host=None, port=22,
+                only_cache=True
+            ),
+            call(
+                'https://example.com/some/repo/to/the/vagrantfiles.git',
+                'vagrantfiles', host=None, port=22,
+                only_cache=True
+            )
+        )
+        self.assertCountEqual(
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
+        )
+
+    def test_ensure_source_on_machine_ensures_latest_source_for_all_provisioning_configs_for_specified_host(self):
+        ensure_source_on_machine(host='1.2.3.4')
+
+        expected_calls = (
+            call(
+                'file:///some/repo/to/the/puppetfiles.git',
+                'puppetfiles', host='1.2.3.4', port=22,
+                only_cache=False
+            ),
+            call(
+                'https://example.com/some/repo/to/the/vagrantfiles.git',
+                'vagrantfiles', host='1.2.3.4', port=22,
+                only_cache=False
+            )
+        )
+        self.assertCountEqual(
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
+        )
+
+    def test_ensure_source_on_machine_ensures_latest_source_for_all_provisioning_configs_for_specified_port(self):
+        ensure_source_on_machine(host='1.2.3.4', port=4321)
+
+        expected_calls = (
+            call(
+                'file:///some/repo/to/the/puppetfiles.git',
+                'puppetfiles', host='1.2.3.4', port=4321,
+                only_cache=False
+            ),
+            call(
+                'https://example.com/some/repo/to/the/vagrantfiles.git',
+                'vagrantfiles', host='1.2.3.4', port=4321,
+                only_cache=False
+            )
+        )
+        self.assertCountEqual(
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
+        )
+
+    def test_ensure_source_on_machine_performs_callback_for_all_provisioning_configs(self):
+        self.callback = Mock()
+
+        ensure_source_on_machine(callback=self.callback)
+
+        expected_calls = (
+            call(
+                'puppetfiles',
+                {'source': 'file:///some/repo/to/the/puppetfiles.git'}
+            ),
+            call(
+                'vagrantfiles',
+                {'source': 'https://example.com/some/repo/to/the/vagrantfiles.git'}
+            )
+        )
+        self.assertCountEqual(self.callback.mock_calls, expected_calls)

--- a/tests/unit/raptiformica/actions/slave/test_provision_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_provision_machine.py
@@ -62,13 +62,15 @@ class TestProvision(TestCase):
                 'https://github.com/vdloo/raptiformica-map',
                 'raptiformica-map',
                 host='1.2.3.4',
-                port=22
+                port=22,
+                only_cache=False
             ),
             call(
                 'https://github.com/vdloo/puppetfiles',
                 'puppetfiles',
                 host='1.2.3.4',
-                port=22
+                port=22,
+                only_cache=False
             ),
         )
         self.assertCountEqual(

--- a/tests/unit/raptiformica/actions/spawn/test_cache_repos.py
+++ b/tests/unit/raptiformica/actions/spawn/test_cache_repos.py
@@ -1,0 +1,55 @@
+from mock import ANY, call
+
+from raptiformica.actions.spawn import cache_repos
+from raptiformica.shell.cjdns import CJDNS_REPOSITORY
+from raptiformica.shell.consul import CONSUL_KV_REPOSITORY
+from tests.testcase import TestCase
+
+
+class TestCacheRepos(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch(
+            'raptiformica.actions.spawn.log'
+        )
+        self.ensure_source_on_machine = self.set_up_patch(
+            'raptiformica.actions.spawn.ensure_source_on_machine'
+        )
+        self.ensure_latest_source_from_artifacts = self.set_up_patch(
+            'raptiformica.actions.spawn.ensure_latest_source_from_artifacts'
+        )
+
+    def test_cache_repos_logs_info_message(self):
+        cache_repos()
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_cache_repos_ensures_source_on_machine(self):
+        cache_repos()
+
+        self.ensure_source_on_machine.assert_called_once_with(
+            server_type=None, only_cache=True
+        )
+
+    def test_cache_repos_ensures_source_on_machine_using_specified_server_type(self):
+        cache_repos(server_type='workstation')
+
+        self.ensure_source_on_machine.assert_called_once_with(
+            server_type='workstation', only_cache=True
+        )
+
+    def test_cache_repos_ensures_latest_sources_from_artifacts_for_non_provisioning_source(self):
+        cache_repos()
+
+        # These sources are not in the provisioning configs (modules)
+        # but are required for the core code
+        expected_calls = (
+            call(
+                CJDNS_REPOSITORY, "cjdns", only_cache=True
+            ),
+            call(
+                CONSUL_KV_REPOSITORY, "consul-kv", only_cache=True
+            ),
+        )
+        self.assertCountEqual(
+            self.ensure_latest_source_from_artifacts.mock_calls, expected_calls
+        )

--- a/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
+++ b/tests/unit/raptiformica/actions/spawn/test_spawn_machine.py
@@ -9,6 +9,7 @@ class TestSpawnMachine(TestCase):
         self.start_compute_type = self.set_up_patch('raptiformica.actions.spawn.start_compute_type')
         self.start_compute_type.return_value = ('some_uuid_1234', '127.0.0.1', 2222)
         self.fire_hooks = self.set_up_patch('raptiformica.actions.spawn.fire_hooks')
+        self.cache_repos = self.set_up_patch('raptiformica.actions.spawn.cache_repos')
         self.slave_machine = self.set_up_patch('raptiformica.actions.spawn.slave_machine')
         self.get_first_server_type = self.set_up_patch(
             'raptiformica.actions.spawn.get_first_server_type'
@@ -35,6 +36,20 @@ class TestSpawnMachine(TestCase):
         self.start_compute_type.assert_called_once_with(
             server_type=self.get_first_server_type.return_value,
             compute_type=self.get_first_compute_type.return_value
+        )
+
+    def test_spawn_machine_caches_repos_using_the_default_server_type(self):
+        spawn_machine()
+
+        self.cache_repos.assert_called_once_with(
+            server_type=self.get_first_server_type.return_value,
+        )
+
+    def test_spawn_machine_caches_repos_using_a_specified_server_type(self):
+        spawn_machine(server_type='workstation')
+
+        self.cache_repos.assert_called_once_with(
+            server_type='workstation'
         )
 
     def test_spawn_machine_slaves_machine_as_default_server_type(self):
@@ -99,6 +114,7 @@ class TestSpawnMachine(TestCase):
         spawn_machine(server_type='workstation', compute_type='docker', only_check_available=True)
 
         self.assertFalse(self.start_compute_type.called)
+        self.assertFalse(self.cache_repos.called)
         self.assertFalse(self.slave_machine.called)
         self.assertFalse(self.fire_hooks.called)
 

--- a/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
+++ b/tests/unit/raptiformica/shell/git/test_ensure_latest_source_from_artifacts.py
@@ -6,7 +6,9 @@ from tests.testcase import TestCase
 
 
 class TestEnsureLatestSourceFromArtifacts(TestCase):
+
     def setUp(self):
+        self.maxDiff = None
         self.ensure_directory = self.set_up_patch(
             'raptiformica.shell.git.ensure_directory'
         )
@@ -17,6 +19,7 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
             'raptiformica.shell.git.conf'
         )
         self.conf.return_value = Mock(
+            ABS_CACHE_DIR='/home/someuser/.raptiformica.temp.custom',
             CACHE_DIR='.raptiformica.temp.custom',
             INSTALL_DIR='/usr/etc/'
         )
@@ -24,11 +27,11 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
     def test_ensure_latest_source_from_artifacts_ensures_artifacts_directory(self):
         ensure_latest_source_from_artifacts(
             "https://github.com/vdloo/puppetfiles",
-            "puppetfiles", host='1.2.3.4', port=22
+            "puppetfiles", port=22
         )
 
         self.ensure_directory.assert_called_once_with(
-            '.raptiformica.d/artifacts/repositories'
+            '/home/someuser/.raptiformica.temp.custom/artifacts/repositories'
         )
 
     def test_ensure_latest_source_from_artifacts_ensures_artifacts_dir_in_default_cache_on_remote_hosts(self):
@@ -42,6 +45,26 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
         )
 
     def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_install_dir(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", port=22
+        )
+
+        expected_calls = (
+            call(
+                "https://github.com/vdloo/puppetfiles",
+                "puppetfiles", host=None, port=22,
+                destination='/home/someuser/.raptiformica.temp.custom/artifacts/repositories'
+            ),
+            call(
+                "file:///root/.raptiformica.d/artifacts/repositories/puppetfiles",
+                "puppetfiles", host=None, port=22,
+                destination=conf().INSTALL_DIR
+            )
+        )
+        self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)
+
+    def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_install_dir_on_remote_hosts(self):
         ensure_latest_source_from_artifacts(
             "https://github.com/vdloo/puppetfiles",
             "puppetfiles", host='1.2.3.4', port=22
@@ -64,6 +87,40 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
     def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_specified_dir(self):
         ensure_latest_source_from_artifacts(
             "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", port=22,
+            destination='/tmp/some/other/directory'
+        )
+
+        expected_calls = (
+            call(
+                "https://github.com/vdloo/puppetfiles",
+                "puppetfiles", host=None, port=22,
+                destination='/home/someuser/.raptiformica.temp.custom/artifacts/repositories'
+            ),
+            call(
+                "file:///root/.raptiformica.d/artifacts/repositories/puppetfiles",
+                "puppetfiles", host=None, port=22,
+                destination='/tmp/some/other/directory'
+            )
+        )
+        self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)
+
+    def test_ensure_latest_source_from_artifacts_ensures_only_cache_if_only_cache(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", port=22,
+            only_cache=True
+        )
+
+        self.ensure_latest_source.assert_called_once_with(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host=None, port=22,
+            destination='/home/someuser/.raptiformica.temp.custom/artifacts/repositories'
+        )
+
+    def test_ensure_latest_source_from_artifacts_ensures_cached_source_to_specified_dir_on_remote_hosts(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
             "puppetfiles", host='1.2.3.4', port=22,
             destination='/tmp/some/other/directory'
         )
@@ -82,6 +139,19 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
         )
         self.assertCountEqual(self.ensure_latest_source.mock_calls, expected_calls)
 
+    def test_ensure_latest_source_from_artifacts_ensures_only_cache_if_only_cache_on_remote_hosts(self):
+        ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            only_cache=True
+        )
+
+        self.ensure_latest_source.assert_called_once_with(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            destination='.raptiformica.d/artifacts/repositories'
+        )
+
     def test_ensure_latest_source_from_artifacts_returns_cached_ensure_result(self):
         expected_result = Mock()
         self.ensure_latest_source.side_effect = [Mock(), expected_result]
@@ -89,6 +159,19 @@ class TestEnsureLatestSourceFromArtifacts(TestCase):
         ret = ensure_latest_source_from_artifacts(
             "https://github.com/vdloo/puppetfiles",
             "puppetfiles", host='1.2.3.4', port=22
+        )
+
+        self.assertEqual(ret, expected_result)
+
+    def test_ensure_latest_source_from_artifacts_returns_cache_creation_ensure_result_if_only_cache(self):
+        expected_result = Mock()
+        # Only one ensure_latest_source call was performed
+        self.ensure_latest_source.side_effect = [expected_result]
+
+        ret = ensure_latest_source_from_artifacts(
+            "https://github.com/vdloo/puppetfiles",
+            "puppetfiles", host='1.2.3.4', port=22,
+            only_cache=True
         )
 
         self.assertEqual(ret, expected_result)


### PR DESCRIPTION
so the guests don't have to download all resources individually when the client host is not in the cluster