### PR TITLE
fix check if port available

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -275,9 +275,8 @@ def check_if_port_available_factory(port):
         :param int port: The port to check
         :return bool not_in_use: True if not in use, False if in use
         """
-        check_port_command = "netstat -tuna | grep {:d} && " \
-                             "/bin/false || /bin/true".format(port)
-        return check_nonzero_exit(check_port_command)
+        check_port_command = "netstat -tuna | grep {:d}".format(port)
+        return not check_nonzero_exit(check_port_command)
     return check_if_port_available
 
 

--- a/tests/unit/raptiformica/actions/mesh/test_check_if_port_available_factory.py
+++ b/tests/unit/raptiformica/actions/mesh/test_check_if_port_available_factory.py
@@ -16,19 +16,18 @@ class TestCheckIfPortAvailableFactory(TestCase):
         check_if_port_available_factory(mock_port)()
 
         self.check_nonzero_exit.assert_called_once_with(
-            "netstat -tuna | grep {:d} && "
-            "/bin/false || /bin/true".format(mock_port)
+            "netstat -tuna | grep {:d}".format(mock_port)
         )
 
     def test_check_if_port_available_factory_returns_true_if_port_available(self):
-        self.check_nonzero_exit.return_value = True
+        self.check_nonzero_exit.return_value = False
 
         ret = check_if_port_available_factory(123)()
 
         self.assertTrue(ret)
 
     def test_check_if_port_available_factory_returns_false_if_port_not_available(self):
-        self.check_nonzero_exit.return_value = False
+        self.check_nonzero_exit.return_value = True
 
         ret = check_if_port_available_factory(123)()
 


### PR DESCRIPTION
This is always true:
```bash
/bin/true && /bin/false || /bin/true
```