### PR TITLE
ensure ipv6 is not disabled at the kernel level

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_cjdns_routing.py
@@ -19,6 +19,9 @@ class TestEnsureCjdnsRouting(TestCase):
         self.block_until_cjdroute_port_is_free = self.set_up_patch(
             'raptiformica.actions.mesh.block_until_cjdroute_port_is_free'
         )
+        self.ensure_ipv6_enabled = self.set_up_patch(
+            'raptiformica.actions.mesh.ensure_ipv6_enabled'
+        )
         self.start_detached_cjdroute = self.set_up_patch(
             'raptiformica.actions.mesh.start_detached_cjdroute'
         )
@@ -79,6 +82,13 @@ class TestEnsureCjdnsRouting(TestCase):
 
         self.block_until_cjdroute_port_is_free.assert_called_once_with()
 
+    def test_ensure_cjdns_routing_ensures_ipv6_enabled(self):
+        self.cjdroute_config_hash_outdated.return_value = True
+
+        ensure_cjdns_routing()
+
+        self.ensure_ipv6_enabled.assert_called_once_with()
+
     def test_ensure_cjdns_routing_starts_detached_cjdroute_if_config_hash_up_to_date_and_tun0_available(self):
         self.cjdroute_config_hash_outdated.return_value = True
 
@@ -122,6 +132,14 @@ class TestEnsureCjdnsRouting(TestCase):
         ensure_cjdns_routing()
 
         self.block_until_cjdroute_port_is_free.assert_called_once_with()
+
+    def test_ensure_cjdns_routing_ensure_ipv6_enabled_if_tun0_not_available(self):
+        self.cjdroute_config_hash_outdated.return_value = False
+        self.check_if_tun0_is_available.return_value = False
+
+        ensure_cjdns_routing()
+
+        self.ensure_ipv6_enabled.assert_called_once_with()
 
     def test_ensure_cjdns_routing_starts_detached_cjdroute_if_tun0_not_available(self):
         self.cjdroute_config_hash_outdated.return_value = False
@@ -171,6 +189,14 @@ class TestEnsureCjdnsRouting(TestCase):
 
         self.assertFalse(self.block_until_cjdroute_port_is_free.called)
 
+    def test_ensure_cjdns_routing_does_not_ensure_ipv6_enabled_if_config_hash_up_to_date_and_tun0(self):
+        self.cjdroute_config_hash_outdated.return_value = False
+        self.check_if_tun0_is_available.return_value = True
+
+        ensure_cjdns_routing()
+
+        self.assertFalse(self.ensure_ipv6_enabled.called)
+
     def test_ensure_cjdns_routing_does_not_start_detached_cjdroute_if_config_hash_up_to_date_and_tun0_available(self):
         self.cjdroute_config_hash_outdated.return_value = False
         self.check_if_tun0_is_available.return_value = True
@@ -212,6 +238,7 @@ class TestEnsureCjdnsRouting(TestCase):
         self.assertEqual(2, self.cjdroute_config_hash_outdated.call_count)
         self.assertEqual(2, self.stop_detached_cjdroute.call_count)
         self.assertEqual(2, self.block_until_cjdroute_port_is_free.call_count)
+        self.assertEqual(2, self.ensure_ipv6_enabled.call_count)
         self.assertEqual(2, self.start_detached_cjdroute.call_count)
         self.assertEqual(2, self.write_cjdroute_config_hash.call_count)
         self.assertEqual(2, self.block_until_tun0_becomes_available.call_count)

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_ipv6_enabled.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_ipv6_enabled.py
@@ -1,0 +1,38 @@
+from mock import ANY
+
+from raptiformica.actions.mesh import ensure_ipv6_enabled
+from tests.testcase import TestCase
+
+
+class TestEnsureIPv6Enabled(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.run_command_print_ready = self.set_up_patch(
+            'raptiformica.actions.mesh.run_command_print_ready'
+        )
+        self.run_command_print_ready = self.set_up_patch(
+            'raptiformica.actions.mesh.run_command_print_ready'
+        )
+        self.log_failure_factory = self.set_up_patch(
+            'raptiformica.actions.mesh.log_failure_factory'
+        )
+
+    def test_ensure_ipv6_enabled_logs_info_message(self):
+        ensure_ipv6_enabled()
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_ensure_ipv6_enabled_configures_ipv6_not_disabled_at_kernel_level(self):
+        ensure_ipv6_enabled()
+
+        self.run_command_print_ready.assert_called_once_with(
+            "/usr/bin/env sysctl net.ipv6.conf.all.disable_ipv6=0",
+            failure_callback=self.log_failure_factory.return_value,
+            shell=True,
+            buffered=False
+        )
+
+    def test_ensure_ipv6_enabled_uses_log_failure_factory(self):
+        ensure_ipv6_enabled()
+
+        self.log_failure_factory.assert_called_once_with(ANY)


### PR DESCRIPTION
because then cjdroute will fail to configure the tunnel and there will be no IP address bound to the tun0 interface
```
1497708287 INFO Configurator.c:427 Creating new ETHInterface [eth0]
1497708287 INFO Configurator.c:388 Setting beacon mode on ETHInterface to [0].
1497708287 WARN Configurator.c:111 Got error [Failed to configure tunnel [NetPlatform_linux.c:153 ioctl(SIOCSIFADDR) [Permission denied]]] calling [Core_initTunnel], ignoring.
```

```
5: tun0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 500
    link/none
```