### PR TITLE
gracefully terminate consul on restart

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -464,7 +464,7 @@ def ensure_no_consul_running():
     kill_running = "ps aux | grep [c]onsul | awk '{print $2}' | " \
                    "xargs --no-run-if-empty -I {} " \
                    "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                   "grep -qv docker /proc/1/cgroup || kill {}\""
+                   "grep -qv docker /proc/1/cgroup || kill -SIGINT {}\""
     run_command_print_ready(
         kill_running,
         shell=True,


### PR DESCRIPTION
On restart, consul should be gracefully stopped. Currently it just
receives a kill (SIGTERM) which might leave the socket in TCP-WAIT
and then Linux will wait for around 60 seconds to free the 8300 port
for reuse. By sending a SIGINT instead consul will gracefully be
stopped and the port will be ready for reuse immediately.

https://groups.google.com/forum/#!topic/consul-tool/J39dzOVkOaY
https://imaginea.gitbooks.io/consul-devops-handbook/content/consul_responses_to_signals.html

Also see https://vincent.bernat.im/en/blog/2014-tcp-time-wait-state-linux