### PR TITLE
generate deterministic node id based on ipv6 addr

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -1,5 +1,8 @@
 import pipes
+from hashlib import md5
 from contextlib import suppress
+from uuid import UUID
+
 from os import remove
 from os.path import join, isfile
 from logging import getLogger
@@ -139,12 +142,17 @@ def configure_consul_conf():
                              "./bin/raptiformica_hook.py cluster_change " \
                              "--verbose\"".format(conf().RAPTIFORMICA_DIR)
     shared_secret = get_consul_password(get_config_mapping())
+    node_id = str(
+        UUID(bytes=md5(str.encode(cjdroute_config['ipv6'])).digest())
+    )
     consul_config = {
         'bootstrap_expect': 3,
         'data_dir': '/opt/consul',
         'datacenter': 'raptiformica',
         'log_level': 'INFO',
         'node_name': cjdroute_config['ipv6'],
+        # deterministic node ID derived from the IPv6 address
+        'node_id': node_id,
         'server': True,
         'bind_addr': '::',  # todo: bind only to the TUN ipv6 address
         'advertise_addr': cjdroute_config['ipv6'],

--- a/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
@@ -61,6 +61,8 @@ class TestConfigureConsulConf(TestCase):
             'datacenter': 'raptiformica',
             'log_level': 'INFO',
             'node_name': 'the_ipv6_address',
+            # deterministic node ID derived from the IPv6 address
+            'node_id': '1d08bba2-6d04-b253-d647-a7fd84e2002a',
             'server': True,
             'bind_addr': '::',
             'advertise_addr': 'the_ipv6_address',


### PR DESCRIPTION
Broke container based deployments since consul 0.8.0. The node-id option was added in 0.7.3.

```
Error joining address '[fc23:f496:8787:99e2:9587:9b4d:a7e6:7338]:8301': Unexpected response code: 500 (1 error(s) occurred:

* Failed to join fc23:f496:8787:99e2:9587:9b4d:a7e6:7338: Member 'fc23:f496:8787:99e2:9587:9b4d:a7e6:7338' has conflicting node ID 'f23f1f3d-d055-bd53-1231-e2d8ad9bbd65' with this agent's ID)
Error joining address '[fb2d:96b2:84b0:97df:43d9:7e88:96bf:222a]:8301': Unexpected response code: 500 (1 error(s) occurred:
```

Now deriving a deterministic UUID format string from the IPv6 address using:
```
import uuid
import hashlib
uuid.UUID(bytes=hashlib.md5("fc23:e5c6:b4fe:f7c8:5f2e:236e:1cbb:cd10").digest())
```