### PR TITLE
remove kill bashism in sh subshell

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -498,7 +498,7 @@ def ensure_no_consul_running():
     kill_running = "ps aux | grep [c]onsul | awk '{print $2}' | " \
                    "xargs --no-run-if-empty -I {} " \
                    "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                   "grep -qv docker /proc/1/cgroup || kill -SIGINT {}\""
+                   "grep -qv docker /proc/1/cgroup || kill -2 {}\""  # SIGINT
     run_command_print_ready(
         kill_running,
         shell=True,

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_no_consul_running.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_no_consul_running.py
@@ -22,7 +22,7 @@ class TestEnsureNoConsulRunning(TestCase):
         expected_command = "ps aux | grep [c]onsul | awk '{print $2}' | " \
                            "xargs --no-run-if-empty -I {} " \
                            "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                           "grep -qv docker /proc/1/cgroup || kill -SIGINT {}\""
+                           "grep -qv docker /proc/1/cgroup || kill -2 {}\""
         self.run_command_print_ready.assert_called_once_with(
             expected_command,
             shell=True,
@@ -47,18 +47,18 @@ class TestEnsureNoConsulRunning(TestCase):
         )
         self.assertIn(
             "-I {} sh -c \"grep -q docker /proc/{}/cgroup && "
-            "grep -qv docker /proc/1/cgroup || kill -SIGINT {}\"",
+            "grep -qv docker /proc/1/cgroup || kill -2 {}\"",
             expected_command,
             'Should only kill processes not in Docker containers unless '
             'running inside a Docker, those could have their own raptiformica '
             'instances running'
         )
         self.assertIn(
-            "kill -SIGINT",
+            "kill -2",
             expected_command,
             'Should gracefully kill consul. The default kill signal is '
             'SIGTERM. Consul does not shut down gracefully on SIGTERM, '
-            'only on SIGINT. If it does not shut down gracefully there '
+            'only on SIGINT (2). If it does not shut down gracefully there '
             'is a chance that the socket will enter a TCP-WAIT state '
             'after which Linux has a timeout of around 60 seconds before '
             'the port becomes available again'


### PR DESCRIPTION
kill -SIGNAL is a bashism apparently. this caused the consul daemon not to
restart after key change in case of a linked or tree cluster. The
incoming data would not be decodable on the last node.

```
root@host:~# sh -c 'kill -SIGINT 1234'
sh: 1: kill: Illegal option -S
root@host:~# bash -c 'kill -SIGINT 1234'
bash: line 0: kill: (1234) - No such process
```