### PR TITLE
remove bash shorthand stderr redir

### DIFF
--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -12,7 +12,7 @@ if [ ! -f cjdroute ]; then
         cp ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/cjdroute .
     else
         echo 'compiling new cjdoute'
-        lsb_release -a |& grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
+        lsb_release -a 2>&1 | grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
         mkdir -p ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
         cp -f cjdroute ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
     fi


### PR DESCRIPTION
script should use 2>&1 instead of |& because sh should suffice