### PR TITLE
retry getting shared secret

### DIFF
--- a/tests/unit/raptiformica/settings/meshnet/test_ensure_shared_secret.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_ensure_shared_secret.py
@@ -4,27 +4,46 @@ from tests.testcase import TestCase
 
 class TestEnsureSharedSecret(TestCase):
     def setUp(self):
-        self.uuid = self.set_up_patch('raptiformica.settings.meshnet.uuid')
-        self.uuid.uuid4.return_value.hex = 'a_generated_shared_secret'
-        self.try_update_config = self.set_up_patch(
-            'raptiformica.settings.meshnet.try_update_config_mapping'
+        self.retrieve_shared_secret = self.set_up_patch(
+            'raptiformica.settings.meshnet.retrieve_shared_secret'
         )
-        self.get_config = self.set_up_patch('raptiformica.settings.meshnet.get_config_mapping')
-        self.get_config.return_value = {
-            'raptiformica/meshnet/consul/password': 'a_secret'
+        self.set_new_shared_secret = self.set_up_patch(
+            'raptiformica.settings.meshnet.set_new_shared_secret'
+        )
+        self.retrieve_shared_secret.return_value = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret',
+            'raptiformica/meshnet/consul/password': 'b_generated_shared_secret'
         }
 
-    def test_ensure_shared_secret_does_not_update_secret_if_it_already_exists(self):
+    def test_ensure_shared_secret_retrieves_shared_secret(self):
+        ensure_shared_secret('consul')
+
+        self.retrieve_shared_secret.assert_called_once_with('consul')
+
+    def test_ensure_shared_secret_does_not_set_new_shared_secret_if_path_is_not_empty(self):
+        ensure_shared_secret('consul')
+
+        self.assertFalse(self.set_new_shared_secret.called)
+
+    def test_ensure_shared_secret_sets_new_shared_secret_if_path_is_empty(self):
+        self.retrieve_shared_secret.return_value = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+
+        ensure_shared_secret('consul')
+
+        self.set_new_shared_secret.assert_called_once_with('consul')
+
+    def test_ensure_shared_secret_returns_retrieved_mapping_if_path_is_not_empty(self):
         ret = ensure_shared_secret('consul')
 
-        self.assertEquals(ret, self.get_config.return_value)
+        self.assertEqual(ret, self.retrieve_shared_secret.return_value)
 
-    def test_ensure_shared_secret_generates_new_shared_secret_if_it_does_not_exist(self):
-        self.get_config.return_value = {}
+    def test_ensure_shared_secret_returns_updated_mapping_if_path_is_empty(self):
+        self.retrieve_shared_secret.return_value = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
 
         ret = ensure_shared_secret('consul')
 
-        self.try_update_config.assert_called_once_with({
-            'raptiformica/meshnet/consul/password': 'a_generated_shared_secret'
-        })
-        self.assertEqual(ret, self.try_update_config.return_value)
+        self.assertEqual(ret, self.set_new_shared_secret.return_value)

--- a/tests/unit/raptiformica/settings/meshnet/test_retrieve_shared_secret.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_retrieve_shared_secret.py
@@ -1,0 +1,102 @@
+from raptiformica.settings.meshnet import retrieve_shared_secret
+from tests.testcase import TestCase
+
+
+class TestRetrieveSharedSecret(TestCase):
+    def setUp(self):
+        self.get_config_mapping = self.set_up_patch(
+            'raptiformica.settings.meshnet.get_config_mapping'
+        )
+        self.sleep = self.set_up_patch(
+            'raptiformica.settings.meshnet.sleep'
+        )
+        self.mapping = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret',
+            'raptiformica/meshnet/consul/password': 'b_generated_shared_secret'
+        }
+        self.get_config_mapping.return_value = self.mapping
+
+    def test_retrieve_shared_secret_gets_config_mapping(self):
+        retrieve_shared_secret('consul', attempts=1)
+
+        self.get_config_mapping.assert_called_once_with()
+
+    def test_retrieve_shared_secret_returns_retrieved_mapping(self):
+        ret = retrieve_shared_secret('consul', attempts=1)
+
+        self.assertEqual(ret, self.mapping)
+
+    def test_retrieve_shared_secret_returns_retrieved_mapping_if_missing_shared_secret(self):
+        self.mapping = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.return_value = self.mapping
+
+        ret = retrieve_shared_secret('consul', attempts=1)
+
+        self.assertEqual(ret, self.mapping)
+
+    def test_retrieve_shared_secret_does_not_sleep_if_missing_shared_secret(self):
+        self.mapping = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.return_value = self.mapping
+
+        retrieve_shared_secret('consul', attempts=1)
+
+        self.assertFalse(self.sleep.called)
+
+    def test_retrieve_shared_secret_retries_if_missing_shared_secret_and_attempts_left(self):
+        self.mapping_with_missing_secret = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.side_effect = (
+            self.mapping_with_missing_secret,
+            self.mapping
+        )
+
+        ret = retrieve_shared_secret('consul', attempts=2)
+
+        self.assertEqual(ret, self.mapping)
+
+    def test_retrieve_shared_secret_sleeps_if_missing_shared_secret_and_attempt_left(self):
+        self.mapping_with_missing_secret = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.side_effect = (
+            self.mapping_with_missing_secret,
+            self.mapping
+        )
+
+        retrieve_shared_secret('consul', attempts=2)
+
+        self.sleep.assert_called_once_with(1)
+
+    def test_retrieve_shared_secret_returns_mapping_with_missing_secret_if_attempts_ran_out(self):
+        self.mapping_with_missing_secret = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.side_effect = (
+            self.mapping_with_missing_secret,
+            self.mapping_with_missing_secret,
+            self.mapping
+        )
+
+        ret = retrieve_shared_secret('consul', attempts=2)
+
+        self.assertEqual(ret, self.mapping_with_missing_secret)
+
+    def test_retrieve_shared_secret_sleeps_once_with_missing_secret_if_attempts_ran_out(self):
+        self.mapping_with_missing_secret = {
+            'raptiformica/meshnet/cjdns/password': 'a_generated_shared_secret'
+        }
+        self.get_config_mapping.side_effect = (
+            self.mapping_with_missing_secret,
+            self.mapping_with_missing_secret,
+            self.mapping
+        )
+
+        retrieve_shared_secret('consul', attempts=2)
+
+        self.sleep.assert_called_once_with(1)
+

--- a/tests/unit/raptiformica/settings/meshnet/test_set_new_shared_secret.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_set_new_shared_secret.py
@@ -1,0 +1,38 @@
+from mock import ANY
+
+from raptiformica.settings.meshnet import set_new_shared_secret
+from tests.testcase import TestCase
+
+
+class TestSetNewSharedSecret(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.settings.meshnet.log')
+        self.uuid = self.set_up_patch('raptiformica.settings.meshnet.uuid')
+        self.uuid.uuid4.return_value.hex = 'new_shared_secret'
+        self.try_update_config = self.set_up_patch(
+            'raptiformica.settings.meshnet.try_update_config_mapping'
+        )
+
+    def test_set_new_shared_secret_logs_info_message(self):
+        set_new_shared_secret('consul')
+
+        self.log.info.assert_called_once_with(ANY)
+
+    def test_set_new_shared_secret_tries_updating_config_mapping_with_consul_secret(self):
+        set_new_shared_secret('consul')
+
+        self.try_update_config.assert_called_once_with(
+            {'raptiformica/meshnet/consul/password': 'new_shared_secret'}
+        )
+
+    def test_set_new_shared_secret_tries_updating_config_mapping_with_cjdns_secret(self):
+        set_new_shared_secret('cjdns')
+
+        self.try_update_config.assert_called_once_with(
+            {'raptiformica/meshnet/cjdns/password': 'new_shared_secret'}
+        )
+
+    def test_new_shared_secret_returns_updated_mapping(self):
+        ret = set_new_shared_secret('some_service')
+
+        self.assertEqual(ret, self.try_update_config.return_value)


### PR DESCRIPTION
re-generating the shared secret will likely result in a netsplit. before
we do so let's first retry getting any existing key a couple more times.
downside of this is that it will block for 10s in the retry loop for
each service in case there actually is no secret yet.