### PR TITLE
add timeout to blocking stdout pipe read

### DIFF
--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -6,17 +6,19 @@ from os.path import isdir, join
 from raptiformica.settings import conf, Config
 from raptiformica.shell.execute import run_command_print_ready, raise_failure_factory, log_success_factory
 from raptiformica.shell.raptiformica import create_remote_raptiformica_cache
+from raptiformica.utils import retry
 
 log = getLogger(__name__)
 
 
-def download(source, destination, host, port=22):
+def download(source, destination, host, port=22, timeout=1800):
     """
     Upload the source path from the local host to the destination path on the remote host
     :param str source: path to sync from on the local host
     :param str destination: path to sync to on the remote machine
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param int timeout: The amount of time the command is allowed to run before terminating it.
     :return bool status: success or failure
     """
     download_command = [
@@ -35,18 +37,20 @@ def download(source, destination, host, port=22):
         failure_callback=raise_failure_factory(
             "Something went wrong downloading files from the remote host"
         ),
-        buffered=False
+        buffered=False,
+        timeout=timeout
     )
     return exit_code
 
 
-def upload(source, destination, host, port=22):
+def upload(source, destination, host, port=22, timeout=1800):
     """
     Upload the source path from the local host to the destination path on the remote host
     :param str source: path to sync from on the local host
     :param str destination: path to sync to on the remote machine
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
+    :param int timeout: The amount of time the command is allowed to run before terminating it.
     :return bool status: success or failure
     """
     upload_command = [
@@ -67,11 +71,13 @@ def upload(source, destination, host, port=22):
         failure_callback=raise_failure_factory(
             "Something went wrong uploading files to the remote host"
         ),
-        buffered=False
+        buffered=False,
+        timeout=timeout
     )
     return exit_code
 
 
+@retry(attempts=3, expect=(TimeoutError,))
 def upload_self(host, port=22):
     """
     Upload the source code of the current raptiformica checkout to the remote host.
@@ -81,7 +87,7 @@ def upload_self(host, port=22):
     :return bool status: True if success, False if failure
     """
     log.info("Uploading raptiformica to the remote host")
-    upload_partial = partial(upload, host=host, port=port)
+    upload_partial = partial(upload, host=host, port=port, timeout=60)
     upload_project_exit_code = upload_partial(
         conf().PROJECT_DIR, conf().INSTALL_DIR
     )
@@ -98,6 +104,7 @@ def upload_self(host, port=22):
     )
 
 
+@retry(attempts=3, expect=(TimeoutError,))
 def download_artifacts(host, port=22):
     """
     If new artifacts were created copy those back to this machine so that
@@ -108,7 +115,7 @@ def download_artifacts(host, port=22):
     :return bool status: True if success, False if failure
     """
     log.info("Downloading artifacts from the remote host")
-    download_partial = partial(download, host=host, port=port)
+    download_partial = partial(download, host=host, port=port, timeout=60)
     download_artifacts_exit_code = download_partial(
         join(Config.CACHE_DIR, 'artifacts'), conf().ABS_CACHE_DIR
     )

--- a/raptiformica/shell/wget.py
+++ b/raptiformica/shell/wget.py
@@ -1,6 +1,10 @@
 from raptiformica.shell.execute import run_critical_unbuffered_command_print_ready
+from raptiformica.utils import retry
+
+WGET_TIMEOUT = 15
 
 
+@retry(attempts=3, expect=(TimeoutError,))
 def wget(url, host=None, port=22, failure_message='Failed retrieving file'):
     """
     Download a file on the remote host
@@ -14,5 +18,5 @@ def wget(url, host=None, port=22, failure_message='Failed retrieving file'):
     """
     run_critical_unbuffered_command_print_ready(
         ['wget', '-nc', url], host=host, port=port,
-        failure_message=failure_message
+        failure_message=failure_message, timeout=WGET_TIMEOUT
     )

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_raptiformica_agent.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_raptiformica_agent.py
@@ -26,7 +26,8 @@ class TestEnsureRaptiformicaAgent(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
-            buffered=False
+            buffered=False,
+            timeout=1800
         )
 
     def test_ensure_raptiformica_agent_raises_error_when_starting_agent_failed(self):

--- a/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_detached_cjdroute.py
@@ -25,7 +25,8 @@ class TestStartDetachedCjdroute(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
-            buffered=False
+            buffered=False,
+            timeout=1800
         )
 
     def test_start_detached_cjdroute_raises_error_when_starting_detached_cjdroute_failed(self):

--- a/tests/unit/raptiformica/actions/mesh/test_start_detached_consul_agent.py
+++ b/tests/unit/raptiformica/actions/mesh/test_start_detached_consul_agent.py
@@ -26,7 +26,8 @@ class TestStartDetachedConsulAgent(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
-            buffered=False
+            buffered=False,
+            timeout=1800
         )
 
     def test_start_detached_consul_agent_raises_error_when_starting_detached_consul_agent_failed(self):

--- a/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
@@ -26,7 +26,8 @@ class TestStopDetachedCjdroute(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
-            buffered=False
+            buffered=False,
+            timeout=1800
         )
         self.assertIn(
             'ps aux |', expected_command,

--- a/tests/unit/raptiformica/actions/prune/test_check_if_instance_is_stale.py
+++ b/tests/unit/raptiformica/actions/prune/test_check_if_instance_is_stale.py
@@ -35,7 +35,8 @@ class TestCheckIfInstanceIsStale(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=True,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_check_if_instance_is_stale_returns_true_if_instance_is_stale(self):

--- a/tests/unit/raptiformica/actions/prune/test_clean_up_stale_instance.py
+++ b/tests/unit/raptiformica/actions/prune/test_clean_up_stale_instance.py
@@ -33,9 +33,10 @@ class TestCleanUpStaleInstance(TestCase):
                             'docker/headless/a_generated_uuid; '
                             '{}'.format(self.clean_up_stale_instance_command)]
         self.execute_process.assert_called_once_with(
-                expected_command,
-                buffered=True,
-                shell=False
+            expected_command,
+            buffered=True,
+            shell=False,
+            timeout=1800
         )
 
     def test_clean_up_stale_instance_does_not_raise_error_when_command_failed(self):

--- a/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
+++ b/tests/unit/raptiformica/distributed/exec/test_try_machine_command.py
@@ -68,7 +68,15 @@ class TestTryMachineCommand(TestCase):
             expected_command_as_list2,
             expected_command_as_list3
         ]
-        expected_calls = map(partial(call, buffered=True, shell=False), expected_command_list)
+        expected_calls = map(
+            partial(
+                call,
+                buffered=True,
+                shell=False,
+                timeout=1800
+            ),
+            expected_command_list
+        )
         self.assertCountEqual(self.execute_process.mock_calls, expected_calls)
 
     def test_try_machine_command_runs_remote_command_on_the_amount_of_specified_hosts_until_one_returns_zero(self):
@@ -97,7 +105,15 @@ class TestTryMachineCommand(TestCase):
             expected_command_as_list1,
             expected_command_as_list2,
         ]
-        expected_calls = map(partial(call, buffered=True, shell=False), expected_command_list)
+        expected_calls = map(
+            partial(
+                call,
+                buffered=True,
+                shell=False,
+                timeout=1800
+            ),
+            expected_command_list
+        )
         self.assertCountEqual(self.execute_process.mock_calls, expected_calls)
 
     def test_try_machine_command_returns_remote_command_output(self):

--- a/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_cjdns_setup.py
@@ -30,7 +30,8 @@ class TestCjdnsSetup(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=True
+            shell=True,
+            timeout=1800
         )
 
     def test_cjdns_setup_raises_error_when_cjdns_setup_script_fails(self):

--- a/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_ensure_cjdns_dependencies.py
@@ -27,7 +27,7 @@ class TestEnsureCjdnsDependencies(TestCase):
             'pacman -S --noconfirm nodejs base-devel iputils --needed '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             '/usr/bin/env ssh -A '
@@ -41,7 +41,7 @@ class TestEnsureCjdnsDependencies(TestCase):
             'build-essential git python iputils-ping '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)
@@ -53,14 +53,14 @@ class TestEnsureCjdnsDependencies(TestCase):
             'type pacman 1> /dev/null && '
             'pacman -S --noconfirm nodejs base-devel iputils --needed '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             'type apt-get 1> /dev/null && '
             'apt-get install -yy nodejs '
             'build-essential git python iputils-ping '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)

--- a/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
+++ b/tests/unit/raptiformica/shell/cjdns/test_get_cjdns_config_item.py
@@ -29,6 +29,7 @@ class TestGetCjdnsConfigItem(TestCase):
             expected_command,
             buffered=True,
             shell=False,
+            timeout=1800
         )
 
     def test_get_cjdns_config_item_runs_get_item_command_for_ipv6_address(self):
@@ -50,6 +51,7 @@ class TestGetCjdnsConfigItem(TestCase):
             expected_command,
             buffered=True,
             shell=False,
+            timeout=1800
         )
 
     def test_get_cjdns_config_item_raises_error_if_getting_config_item_failed(self):
@@ -60,6 +62,6 @@ class TestGetCjdnsConfigItem(TestCase):
             get_cjdns_config_item('publicKey', '1.2.3.4', port=2222)
 
     def test_get_cjdns_config_item_returns_item(self):
-        ret =  get_cjdns_config_item('publicKey', '1.2.3.4', port=2222)
+        ret = get_cjdns_config_item('publicKey', '1.2.3.4', port=2222)
 
         self.assertEqual(ret, 'standard out output')

--- a/tests/unit/raptiformica/shell/compute/test_boot_instance.py
+++ b/tests/unit/raptiformica/shell/compute/test_boot_instance.py
@@ -32,7 +32,8 @@ class TestBootInstance(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_boot_instance_raises_error_when_command_failed(self):

--- a/tests/unit/raptiformica/shell/compute/test_compute_attribute_get.py
+++ b/tests/unit/raptiformica/shell/compute/test_compute_attribute_get.py
@@ -33,7 +33,8 @@ class TestComputeAttributeGet(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=True,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_compute_attribute_get_returns_stripped_standard_out(self):

--- a/tests/unit/raptiformica/shell/config/test_run_resource_command.py
+++ b/tests/unit/raptiformica/shell/config/test_run_resource_command.py
@@ -31,7 +31,8 @@ class TestRunResourceCommand(TestCase):
         self.execute_process.assert_called_once_with(
             expected_remote_command,
             buffered=False,
-            shell=True
+            shell=True,
+            timeout=1800
         )
 
     def test_run_resource_command_returns_command_output(self):

--- a/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_consul_dependencies.py
@@ -27,7 +27,7 @@ class TestEnsureConsulDependencies(TestCase):
             'pacman -S --noconfirm wget unzip screen --needed '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             '/usr/bin/env ssh -A '
@@ -40,7 +40,7 @@ class TestEnsureConsulDependencies(TestCase):
             'apt-get install -yy wget unzip screen '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)
@@ -52,13 +52,13 @@ class TestEnsureConsulDependencies(TestCase):
             'type pacman 1> /dev/null && '
             'pacman -S --noconfirm wget unzip screen --needed '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             'type apt-get 1> /dev/null && '
             'apt-get install -yy wget unzip screen '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)

--- a/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
@@ -42,8 +42,18 @@ class TestEnsureLatestConsulRelease(TestCase):
             'https://releases.hashicorp.com/consul/0.8.5/consul_0.8.5_web_ui.zip'
         ]
         expected_calls = [
-            call(expected_binary_command, buffered=False, shell=False),
-            call(expected_web_ui_command, buffered=False, shell=False)
+            call(
+                expected_binary_command,
+                buffered=False,
+                shell=False,
+                timeout=15
+            ),
+            call(
+                expected_web_ui_command,
+                buffered=False,
+                shell=False,
+                timeout=15
+            )
         ]
         self.assertCountEqual(self.execute_process.mock_calls, expected_calls)
 

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_binary.py
@@ -31,9 +31,10 @@ class TestUnzipConsulBinary(TestCase):
             '-d', '/usr/bin'
         ]
         self.execute_process.assert_called_once_with(
-                expected_command,
-                buffered=False,
-                shell=False
+            expected_command,
+            buffered=False,
+            shell=False,
+            timeout=1800
         )
 
     def test_unzip_consul_binary_raises_error_when_ensuring_latest_release_fails(self):

--- a/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
+++ b/tests/unit/raptiformica/shell/consul/test_unzip_consul_web_ui.py
@@ -33,7 +33,8 @@ class TestUnzipConsulWebUI(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_unzip_consul_web_ui_raises_error_when_ensuring_latest_web_ui_files_fails(self):

--- a/tests/unit/raptiformica/shell/execute/test_terminate_and_kill.py
+++ b/tests/unit/raptiformica/shell/execute/test_terminate_and_kill.py
@@ -1,0 +1,25 @@
+from contextlib import suppress
+
+from mock import Mock
+
+from raptiformica.shell.execute import terminate_and_kill
+from tests.testcase import TestCase
+
+
+class TestTerminateAndKill(TestCase):
+    def setUp(self):
+        self.process = Mock()
+
+    def test_terminate_and_kill_terminates_process(self):
+        with suppress(TimeoutError):
+            terminate_and_kill(self.process, 10, "sleep 1000")
+            self.process.terminate.assert_called_once_with()
+
+    def test_terminate_and_kill_kills_process(self):
+        with suppress(TimeoutError):
+            terminate_and_kill(self.process, 10, "sleep 1000")
+            self.process.kill.assert_called_once_with()
+
+    def test_terminate_and_kill_raises_timeout_error(self):
+        with self.assertRaises(TimeoutError):
+            terminate_and_kill(self.process, 10, "sleep 1000")

--- a/tests/unit/raptiformica/shell/execute/test_terminate_on_timeout.py
+++ b/tests/unit/raptiformica/shell/execute/test_terminate_on_timeout.py
@@ -1,0 +1,35 @@
+from mock import Mock
+
+from raptiformica.shell.execute import terminate_on_timeout, terminate_and_kill
+from tests.testcase import TestCase
+
+
+class TestTerminateOnTimeout(TestCase):
+    def setUp(self):
+        self.process = Mock()
+        self.timer = self.set_up_patch(
+            'raptiformica.shell.execute.Timer'
+        )
+
+    def test_terminate_on_timeout_instantiates_timer_before_context(self):
+        self.assertFalse(self.timer.called)
+
+        with terminate_on_timeout(self.process, 10, "sleep 100"):
+            self.timer.assert_called_once_with(
+                10, terminate_and_kill,
+                args=[self.process, 10, "sleep 100"]
+            )
+
+    def test_terminate_on_timeout_starts_timer_before_context(self):
+        self.assertFalse(self.timer.return_value.start.called)
+
+        with terminate_on_timeout(self.process, 10, "sleep 100"):
+            self.timer.return_value.start.assert_called_once_with()
+
+    def test_terminate_on_timeout_cancels_timer_after_context(self):
+        self.assertFalse(self.timer.return_value.cancel.called)
+
+        with terminate_on_timeout(self.process, 10, "sleep 100"):
+            self.assertFalse(self.timer.return_value.cancel.called)
+
+        self.timer.return_value.cancel.assert_called_once_with()

--- a/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_locally.py
@@ -33,7 +33,8 @@ class TestCloneSourceLocally(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_clone_source_returns_clone_source_command_exit_code(self):

--- a/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
+++ b/tests/unit/raptiformica/shell/git/test_clone_source_remotely.py
@@ -41,7 +41,8 @@ class TestCloneSourceRemotely(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_clone_source_returns_clone_source_command_exit_code(self):

--- a/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
+++ b/tests/unit/raptiformica/shell/git/test_pull_origin_master.py
@@ -29,7 +29,8 @@ class TestPullOriginMaster(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=True
+            shell=True,
+            timeout=1800
         )
 
     def test_that_pull_origin_master_returns_pull_origin_master_exit_code(self):

--- a/tests/unit/raptiformica/shell/git/test_reset_hard_head.py
+++ b/tests/unit/raptiformica/shell/git/test_reset_hard_head.py
@@ -30,7 +30,8 @@ class TestResetHardHead(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=True
+            shell=True,
+            timeout=1800
         )
 
     def test_that_reset_hard_head_returns_exit_code(self):

--- a/tests/unit/raptiformica/shell/package_manager/test_update_package_manager_cache.py
+++ b/tests/unit/raptiformica/shell/package_manager/test_update_package_manager_cache.py
@@ -27,7 +27,7 @@ class TestUpdatePackageManagerCache(TestCase):
             'pacman -Syy '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             '/usr/bin/env ssh -A '
@@ -40,7 +40,7 @@ class TestUpdatePackageManagerCache(TestCase):
             'apt-get update -yy '
             '|| /bin/true'
             '\'',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)
@@ -52,13 +52,13 @@ class TestUpdatePackageManagerCache(TestCase):
             'type pacman 1> /dev/null && '
             'pacman -Syy '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_debian_call = call(
             'type apt-get 1> /dev/null && '
             'apt-get update -yy '
             '|| /bin/true',
-            buffered=False, shell=True
+            buffered=False, shell=True, timeout=1800
         )
         expected_calls = [expected_archlinux_call, expected_debian_call]
         self.assertCountEqual(expected_calls, self.execute_process.mock_calls)

--- a/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_create_remote_raptiformica_cache.py
@@ -31,7 +31,8 @@ class TestCreateRemoteRaptiformicaCache(TestCase):
         self.execute_process.assert_called_once_with(
             expected_upload_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_create_remote_raptiformica_cache_returns_exit_code_0_if_command_succeeded(self):

--- a/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_run_raptiformica_command.py
@@ -40,7 +40,8 @@ class TestRunRaptiformicaCommand(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_run_raptiformica_command_raises_error_if_remote_raptiformica_command_fails(self):

--- a/tests/unit/raptiformica/shell/rsync/test_download.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download.py
@@ -25,7 +25,8 @@ class TestDownload(TestCase):
         self.execute_process.assert_called_once_with(
             expected_download_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_download_raises_error_when_downloading_failed(self):

--- a/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
+++ b/tests/unit/raptiformica/shell/rsync/test_download_artifacts.py
@@ -21,7 +21,8 @@ class TestDownloadArtifacts(TestCase):
             '.raptiformica.d/artifacts',
             conf().ABS_CACHE_DIR,
             host='1.2.3.4',
-            port=2222
+            port=2222,
+            timeout=60
         )
 
     def test_download_artifacts_returns_true_if_success(self):

--- a/tests/unit/raptiformica/shell/rsync/test_upload.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload.py
@@ -24,7 +24,8 @@ class TestUpload(TestCase):
         self.execute_process.assert_called_once_with(
             expected_upload_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_upload_raises_error_when_uploading_failed(self):

--- a/tests/unit/raptiformica/shell/rsync/test_upload_self.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload_self.py
@@ -32,9 +32,9 @@ class TestUploadSelf(TestCase):
 
         expected_calls = [
             call(conf().PROJECT_DIR, conf().INSTALL_DIR, host='1.2.3.4',
-                 port=22),
+                 port=22, timeout=60),
             call(conf().ABS_CACHE_DIR + '/', join("$HOME", Config.CACHE_DIR), host='1.2.3.4',
-                 port=22)
+                 port=22, timeout=60)
         ]
         self.assertCountEqual(self.upload.mock_calls, expected_calls)
 

--- a/tests/unit/raptiformica/shell/ssh/test_verify_ssh_agent_running.py
+++ b/tests/unit/raptiformica/shell/ssh/test_verify_ssh_agent_running.py
@@ -23,7 +23,8 @@ class TestVerifySSHAgentRunning(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=True,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_verify_ssh_agent_running_raises_error_if_exit_code_is_nonzero(self):

--- a/tests/unit/raptiformica/shell/unzip/test_unzip.py
+++ b/tests/unit/raptiformica/shell/unzip/test_unzip.py
@@ -32,7 +32,8 @@ class TestUnzip(TestCase):
         self.execute_process.assert_called_once_with(
             expected_command,
             buffered=False,
-            shell=False
+            shell=False,
+            timeout=1800
         )
 
     def test_unzip_raises_error_when_unzipping_failed(self):

--- a/tests/unit/raptiformica/shell/wget/test_wget.py
+++ b/tests/unit/raptiformica/shell/wget/test_wget.py
@@ -27,9 +27,10 @@ class TestWget(TestCase):
             'wget', '-nc', 'https://www.example.com/some_url.zip'
         ]
         self.execute_process.assert_called_once_with(
-                expected_command,
-                buffered=False,
-                shell=False
+            expected_command,
+            buffered=False,
+            shell=False,
+            timeout=15
         )
 
     def test_wget_raises_error_when_retrieving_the_file_failed(self):


### PR DESCRIPTION
sometimes during high load a shell command will die for various reasons,
in that case the pipe that is being blocking read from by python will
never return anything and the program will block indefinitely. the
threading.Timer runs a separate thread that will kill the process if it
runs out the configured timeout. if required, a retry decorator can be
added to functions that use exec_command with expected=(TimeoutError,)
so the command will be retried in case it is killed.