### PR TITLE
use system installed for default provisioning

### DIFF
--- a/modules/server/default.json
+++ b/modules/server/default.json
@@ -3,7 +3,7 @@
   "server": {
     "headless": {
       "raptiformica_default_provisioner": {
-        "source": "file:///usr/etc/raptiformica",
+        "source": "file:///usr/share/raptiformica",
         "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py"
       }
     }


### PR DESCRIPTION
/usr/etc/raptiformica does not exist if the client is not in the cluster