### PR TITLE
enable_script_checks in consul agent

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -158,6 +158,7 @@ def configure_consul_conf():
         'advertise_addr': cjdroute_config['ipv6'],
         'encrypt': shared_secret,
         'disable_remote_exec': True,
+        'enable_script_checks': True,
         'performance': {
             # High performance settings. Machines leave and join the
             # cluster fast and often.

--- a/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_consul_conf.py
@@ -68,6 +68,7 @@ class TestConfigureConsulConf(TestCase):
             'advertise_addr': 'the_ipv6_address',
             'encrypt': 'a_different_secret',
             'disable_remote_exec': True,
+            'enable_script_checks': True,
             'performance': {
                 # Low sensitivity settings. Machines leave
                 # and join the cluster fast and often.


### PR DESCRIPTION
> Script-based health checks are now opt-in - A new enable_script_checks
> configuration option was added and defaults to false, which means that
> operators must now opt-in in order to allow Consul agents to execute
> scripts

https://www.hashicorp.com/blog/consul-0-9/