### PR TITLE
do not run cjdroute build tests

### DIFF
--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -12,6 +12,7 @@ if [ ! -f cjdroute ]; then
         cp ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/cjdroute .
     else
         echo 'compiling new cjdoute'
+        export NO_TEST=true
         lsb_release -a 2>&1 | grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
         mkdir -p ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
         cp -f cjdroute ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/


### PR DESCRIPTION
still running a 900mhz celeron somewhere and it is too slow to run the tests without timing out
```
Running test Beacon_test                                                           31.639 ms
Running test CryptoAddress_test                                                    1.293 ms
Running test printIp_test                                                          14.918 ms
Running test CryptoAuth_fuzz_test                                                  226.774 ms
Running test CryptoAuth_test                                                       136.999 ms
Running test CryptoAuth_unit_test                                                  10.899 ms
Running test ReplayProtector_test                                                  1.185 ms
Running test Sign_test                                                             4.879 ms
Running test DHTModules_handleIncoming_test                                        0.446 ms
Running test DHTModules_handleOutgoing_test                                        0.331 ms
Running test FramingIface_fuzz_test                                                24.515 ms
Running test FramingIface_test                                                     0.479 ms
Running test FileReader_test                                                       0.830 ms
Running test Allocator_test                                                        0.385 ms
Running test EncodingScheme_test                                                   159.644 ms
Running test LabelSplicer_test                                                     0.449 ms
Running test NumberCompress_test                                                   4.361 ms
Running test PenaltyFloat_test                                                     0.953 ms
Running test IpTunnel_test                                                         2.22 ms
Running test RouteGen_test                                                         75.69 ms
Running test AddrTools_test                                                        0.456 ms
Running test AverageRoller_test                                                    0.364 ms
Running test Base10_test                                                           7.988 ms
Running test Base32_test                                                           0.672 ms
Running test Bits_test                                                             1.216 ms
Running test Checksum_test                                                         0.421 ms
Running test Endian_test                                                           0.296 ms
Running test Hex_test                                                              0.608 ms
Running test Identity_test                                                         0.337 ms
Running test Map_fuzz_test                                                         0.302 ms
Running test Map_test                                                              22.856 ms
Running test Process_testAssertion failure [Process_test.c:75] [(!"timed out.")]
Assertion failure [Process_test.c:75] [(!"timed out.")]
```