### PR TITLE
Build cjdns fork

### DIFF
--- a/raptiformica/shell/cjdns.py
+++ b/raptiformica/shell/cjdns.py
@@ -8,7 +8,7 @@ from raptiformica.shell.execute import raise_failure_factory, \
     run_multiple_labeled_commands
 from raptiformica.shell.git import ensure_latest_source_from_artifacts
 
-CJDNS_REPOSITORY = "https://github.com/cjdelisle/cjdns"
+CJDNS_REPOSITORY = "https://github.com/vdloo/cjdns"
 
 log = getLogger(__name__)
 

--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -12,7 +12,6 @@ if [ ! -f cjdroute ]; then
         cp ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/cjdroute .
     else
         echo 'compiling new cjdoute'
-        export NO_TEST=true
         lsb_release -a 2>&1 | grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
         mkdir -p ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
         cp -f cjdroute ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/


### PR DESCRIPTION
to fix an issue in master where compilation broke due to a change relating to libuv, also see cjdelisle/cjdns#1107

re-enables post compilation tests