### PR TITLE
add clean state command

### DIFF
--- a/bin/raptiformica
+++ b/bin/raptiformica
@@ -11,6 +11,7 @@ JOIN_ENTRYPOINT="raptiformica_join.py"
 MODPROBE_ENTRYPOINT="raptiformica_modprobe.py"
 SSH_ENTRYPOINT="raptiformica_ssh.py"
 INJECT_ENTRYPOINT="raptiformica_inject.py"
+CLEAN_ENTRYPOINT="raptiformica_clean.py"
 
 function print_help {
     cat <<'END'
@@ -42,6 +43,9 @@ Usage: raptiformica [CMD..] [OPTIONS] [-h]
                              distributed network
 
   ssh                        SSH into one of the machines
+
+  clean                      Remove all state on the local 
+                             machine if any.
 END
 }
 
@@ -84,6 +88,10 @@ case $1 in
     ;;
     package)
     RAPTIFORMICA_CMD=$PACKAGE_ENTRYPOINT
+    shift
+    ;;
+    clean)
+    RAPTIFORMICA_CMD=$CLEAN_ENTRYPOINT
     shift
     ;;
     *)

--- a/bin/raptiformica_clean.py
+++ b/bin/raptiformica_clean.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+from raptiformica.cli import clean
+
+if __name__ == '__main__':
+    clean()
+else:
+    raise RuntimeError("This script is an entry point and can not be imported")

--- a/raptiformica/actions/clean.py
+++ b/raptiformica/actions/clean.py
@@ -2,6 +2,8 @@ from logging import getLogger
 
 from shutil import rmtree
 
+from raptiformica.actions.mesh import ensure_no_consul_running, stop_detached_cjdroute
+
 log = getLogger(__name__)
 
 LOCAL_STATE_DIRS = (
@@ -32,6 +34,8 @@ def clean_local_state():
     :return None:
     """
     log.info("Cleaning local state")
+    ensure_no_consul_running()
+    stop_detached_cjdroute()
     for path_to_clean in LOCAL_STATE_DIRS:
         log.debug("Removing {} if it exists".format(path_to_clean))
         rmtree(path_to_clean, ignore_errors=True)

--- a/raptiformica/actions/clean.py
+++ b/raptiformica/actions/clean.py
@@ -1,0 +1,37 @@
+from logging import getLogger
+
+from shutil import rmtree
+
+log = getLogger(__name__)
+
+LOCAL_STATE_DIRS = (
+    '/usr/bin/cjdroute',
+    '/usr/etc/cjdns',
+    '/usr/bin/consul',
+    '/opt/consul',
+    '/usr/etc/raptiformica',
+    '/usr/etc/raptiformica_default_provisioner',
+    '$HOME/.raptiformica.d',
+    '/root/.raptiformica.d'
+)
+
+
+def clean_local_state():
+    """
+    Remove all state so it is as if the local machine
+    will join the cluster for the first time the next
+    time it is slaved.
+
+    Note that this should in theory never be necessary
+    but it can be helpful for debugging to rule out any
+    leaking state issues. For example it could be that
+    one of the instances in the cluster tries to keep
+    connecting to some stale node that for some reason
+    isn't being removed from the settings causing the
+    stability of the mesh to degrade.
+    :return None:
+    """
+    log.info("Cleaning local state")
+    for path_to_clean in LOCAL_STATE_DIRS:
+        log.debug("Removing {} if it exists".format(path_to_clean))
+        rmtree(path_to_clean, ignore_errors=True)

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -3,6 +3,7 @@ from os import environ
 from os.path import expanduser
 
 from raptiformica.actions.agent import run_agent
+from raptiformica.actions.clean import clean_local_state
 from raptiformica.actions.destroy import destroy_cluster
 from raptiformica.actions.hook import trigger_handlers
 from raptiformica.actions.join import join_machine
@@ -444,3 +445,24 @@ def modprobe():
         unload_module(args.name)
     else:
         load_module(args.name)
+
+
+def parse_clean_arguments():
+    """
+    Parse the commandline options for removing all the local state
+    :return obj args: parsed arguments
+    """
+    parser = ArgumentParser(
+        prog="raptiformica clean",
+        description="Clean up all local state if any"
+    )
+    return parse_arguments(parser)
+
+
+def clean():
+    """
+    Clean up all local state if any
+    :return None:
+    """
+    parse_clean_arguments()
+    clean_local_state()

--- a/tests/unit/raptiformica/actions/clean/test_clean_local_state.py
+++ b/tests/unit/raptiformica/actions/clean/test_clean_local_state.py
@@ -1,0 +1,24 @@
+from functools import partial
+from unittest.mock import call
+
+from raptiformica.actions.clean import clean_local_state, LOCAL_STATE_DIRS
+from tests.testcase import TestCase
+
+
+class TestCleanLocalState(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.actions.clean.log')
+        self.rmtree = self.set_up_patch('raptiformica.actions.clean.rmtree')
+
+    def test_clean_local_state_logs_clean_local_state_message(self):
+        clean_local_state()
+
+        self.assertTrue(self.log.info.called)
+
+    def test_clean_local_state_removes_all_state_paths_if_they_exist(self):
+        clean_local_state()
+
+        expected_calls = map(
+            partial(call, ignore_errors=True), LOCAL_STATE_DIRS
+        )
+        self.assertCountEqual(self.rmtree.mock_calls, expected_calls)

--- a/tests/unit/raptiformica/actions/clean/test_clean_local_state.py
+++ b/tests/unit/raptiformica/actions/clean/test_clean_local_state.py
@@ -8,12 +8,28 @@ from tests.testcase import TestCase
 class TestCleanLocalState(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.clean.log')
+        self.ensure_no_consul_running = self.set_up_patch(
+            'raptiformica.actions.clean.ensure_no_consul_running'
+        )
+        self.stop_detached_cjdroute = self.set_up_patch(
+            'raptiformica.actions.clean.stop_detached_cjdroute'
+        )
         self.rmtree = self.set_up_patch('raptiformica.actions.clean.rmtree')
 
     def test_clean_local_state_logs_clean_local_state_message(self):
         clean_local_state()
 
         self.assertTrue(self.log.info.called)
+
+    def test_clean_local_state_kills_any_running_consul(self):
+        clean_local_state()
+
+        self.ensure_no_consul_running.assert_called_once_with()
+
+    def test_clean_local_state_kills_any_running_cjdroute(self):
+        clean_local_state()
+
+        self.stop_detached_cjdroute.assert_called_once_with()
 
     def test_clean_local_state_removes_all_state_paths_if_they_exist(self):
         clean_local_state()

--- a/tests/unit/raptiformica/cli/test_clean.py
+++ b/tests/unit/raptiformica/cli/test_clean.py
@@ -1,0 +1,22 @@
+from raptiformica.cli import clean
+from tests.testcase import TestCase
+
+
+class TestClean(TestCase):
+    def setUp(self):
+        self.parse_clean_arguments = self.set_up_patch(
+            'raptiformica.cli.parse_clean_arguments'
+        )
+        self.clean_local_state = self.set_up_patch(
+            'raptiformica.cli.clean_local_state'
+        )
+
+    def test_clean_parses_clean_arguments(self):
+        clean()
+
+        self.parse_clean_arguments.assert_called_once_with()
+
+    def test_clean_cleans_local_machines(self):
+        clean()
+
+        self.clean_local_state.assert_called_once_with()

--- a/tests/unit/raptiformica/cli/test_parse_clean_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_clean_arguments.py
@@ -1,0 +1,26 @@
+from raptiformica.cli import parse_clean_arguments
+from tests.testcase import TestCase
+
+
+class TestParseCleanArguments(TestCase):
+    def setUp(self):
+        self.argument_parser = self.set_up_patch('raptiformica.cli.ArgumentParser')
+        self.parse_arguments = self.set_up_patch('raptiformica.cli.parse_arguments')
+
+    def test_parse_clean_arguments_instantiates_argparser(self):
+        parse_clean_arguments()
+
+        self.argument_parser.assert_called_once_with(
+            prog='raptiformica clean',
+            description="Clean up all local state if any"
+        )
+
+    def test_parse_clean_arguments_parses_arguments(self):
+        parse_clean_arguments()
+
+        self.parse_arguments.assert_called_once_with(self.argument_parser.return_value)
+
+    def test_parse_clean_arguments_returns_parsed_arguments(self):
+        ret = parse_clean_arguments()
+
+        self.assertEqual(ret, self.parse_arguments.return_value)


### PR DESCRIPTION
Remove all state so it is as if the local machine
will join the cluster for the first time the next
time it is slaved.

Note that this should in theory never be necessary
but it can be helpful for debugging to rule out any
leaking state issues. For example it could be that
one of the instances in the cluster tries to keep
connecting to some stale node that for some reason
isn't being removed from the settings causing the
stability of the mesh to degrade.