### PR TITLE
Integration test concurrently booting clusters

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
-while getopts "1i" opt; do
+while getopts "1icsr" opt; do
     case $opt in
         1) RUN_ONCE=1;;
         i) INTEGRATION=1;;
+        # Skip integration tests that boot all nodes at the same time
+        c) NO_FULL_CONCURRENT=1;;
+        # Skip integration tests that boot all nodes 2 at a time
+        s) NO_SEMI_CONCURRENT=1;;
+        # Skip integration tests that boot all nodes sequentially
+        r) NO_NO_CONCURRENT=1;;
     esac
 done
+
+export NO_FULL_CONCURRENT
+export NO_SEMI_CONCURRENT
+export NO_NO_CONCURRENT
 
 [ -z $INTEGRATION ] && TEST_SUITE="unit" || TEST_SUITE="integration"
 [ -z $INTEGRATION ] && TIME_OUT="--process-timeout=30" || TIME_OUT="--process-timeout=1200"
@@ -48,3 +58,4 @@ if [ -z $RUN_ONCE ] && [ -z $INTEGRATION ]; then
 else
     sh -ec "$test_cmd"
 fi
+

--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -1,4 +1,6 @@
 from multiprocessing.pool import ThreadPool
+from os import environ
+from unittest import SkipTest
 
 from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
@@ -31,7 +33,12 @@ class TestLinkedCluster(IntegrationTestCase):
         for _ in range(self.amount_of_instances):
             run_raptiformica_command(self.temp_cache_dir, spawn_command)
 
+    def skip_if_env_override(self):
+        if environ.get('NO_NO_CONCURRENT'):
+            raise SkipTest
+
     def setUp(self):
+        self.skip_if_env_override()
         super(TestLinkedCluster, self).setUp()
         self.amount_of_instances = 3
         # Spawn 3 un-assimilated Docker instances
@@ -94,6 +101,10 @@ class TestLinkedConcurrentCluster(TestLinkedCluster):
     """
     workers = 3
 
+    def skip_if_env_override(self):
+        if environ.get('NO_FULL_CONCURRENT'):
+            raise SkipTest
+
     def spawn_docker_instances(self):
         spawn_command = "spawn --no-assimilate " \
                         "--server-type headless " \
@@ -112,3 +123,7 @@ class TestLinkedSemiConcurrentCluster(TestLinkedConcurrentCluster):
     at the same time instead of one after the other.
     """
     workers = 2
+
+    def skip_if_env_override(self):
+        if environ.get('NO_SEMI_CONCURRENT'):
+            raise SkipTest

--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -115,6 +115,8 @@ class TestLinkedConcurrentCluster(TestLinkedCluster):
                 run_raptiformica_command,
                 args=(self.temp_cache_dir, spawn_command)
             )
+        pool.close()
+        pool.join()
 
 
 class TestLinkedSemiConcurrentCluster(TestLinkedConcurrentCluster):

--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -1,4 +1,6 @@
-from tests.testcase import IntegrationTestCase
+from multiprocessing.pool import ThreadPool
+
+from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
 
 class TestLinkedCluster(IntegrationTestCase):
@@ -23,19 +25,17 @@ class TestLinkedCluster(IntegrationTestCase):
     not accessible by the first host.
     """
     def spawn_docker_instances(self):
-        self.run_raptiformica_command(
-            "spawn --no-assimilate "
-            "--server-type headless "
-            "--compute-type docker"
-        )
+        spawn_command = "spawn --no-assimilate " \
+                        "--server-type headless " \
+                        "--compute-type docker"
+        for _ in range(self.amount_of_instances):
+            run_raptiformica_command(self.temp_cache_dir, spawn_command)
 
     def setUp(self):
         super(TestLinkedCluster, self).setUp()
         self.amount_of_instances = 3
-
         # Spawn 3 un-assimilated Docker instances
-        for _ in range(self.amount_of_instances):
-            self.spawn_docker_instances()
+        self.spawn_docker_instances()
 
         # List the spawned instances and their IPs
         docker_instances = self.list_relevant_docker_instances()
@@ -56,7 +56,8 @@ class TestLinkedCluster(IntegrationTestCase):
 
         # Assimilate one of the instances from the client (which is not in the cluster)
         # so we can later run raptiformica members without having to log in explicitly.
-        self.run_raptiformica_command(
+        run_raptiformica_command(
+            self.temp_cache_dir,
             "slave {} --server-type headless --verbose".format(docker_ips[0])
         )
 
@@ -84,3 +85,30 @@ class TestLinkedCluster(IntegrationTestCase):
     def test_linked_cluster_establishes_mesh_correctly(self):
         self.check_consul_consensus_was_established(expected_peers=self.amount_of_instances)
         self.check_all_registered_peers_can_be_pinged_from_any_instance()
+
+
+class TestLinkedConcurrentCluster(TestLinkedCluster):
+    """
+    Same as the LinkedCluster case but all instances boot at the same time
+    instead of one after the other.
+    """
+    workers = 3
+
+    def spawn_docker_instances(self):
+        spawn_command = "spawn --no-assimilate " \
+                        "--server-type headless " \
+                        "--compute-type docker"
+        pool = ThreadPool(self.workers)
+        for _ in range(self.amount_of_instances):
+            pool.apply_async(
+                run_raptiformica_command,
+                args=(self.temp_cache_dir, spawn_command)
+            )
+
+
+class TestLinkedSemiConcurrentCluster(TestLinkedConcurrentCluster):
+    """
+    Same as the LinkedCluster case but all two of the three instances boot
+    at the same time instead of one after the other.
+    """
+    workers = 2

--- a/tests/integration/meshnet/test_simple_cluster.py
+++ b/tests/integration/meshnet/test_simple_cluster.py
@@ -75,6 +75,8 @@ class TestSimpleConcurrentCluster(TestSimpleCluster):
                 run_raptiformica_command,
                 args=(self.temp_cache_dir, spawn_command)
             )
+        pool.close()
+        pool.join()
 
 
 class TestSimpleSemiConcurrentCluster(TestSimpleConcurrentCluster):

--- a/tests/integration/meshnet/test_simple_cluster.py
+++ b/tests/integration/meshnet/test_simple_cluster.py
@@ -1,4 +1,6 @@
 from multiprocessing.pool import ThreadPool
+from os import environ
+from unittest import SkipTest
 
 from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
@@ -27,7 +29,12 @@ class TestSimpleCluster(IntegrationTestCase):
         docker_ip = self.get_docker_ip(docker_instances[-1])
         self.slave_instance(docker_ip)
 
+    def skip_if_env_override(self):
+        if environ.get('NO_NO_CONCURRENT'):
+            raise SkipTest
+
     def setUp(self):
+        self.skip_if_env_override()
         super(TestSimpleCluster, self).setUp()
         self.amount_of_instances = 3
         self.spawn_docker_instances()
@@ -56,6 +63,10 @@ class TestSimpleConcurrentCluster(TestSimpleCluster):
     """
     workers = 3
 
+    def skip_if_env_override(self):
+        if environ.get('NO_FULL_CONCURRENT'):
+            raise SkipTest
+
     def spawn_docker_instances(self):
         spawn_command = "spawn --server-type headless --compute-type docker"
         pool = ThreadPool(self.workers)
@@ -72,3 +83,7 @@ class TestSimpleSemiConcurrentCluster(TestSimpleConcurrentCluster):
     at the same time instead of one after the other.
     """
     workers = 2
+
+    def skip_if_env_override(self):
+        if environ.get('NO_SEMI_CONCURRENT'):
+            raise SkipTest

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -1,4 +1,6 @@
 from multiprocessing.pool import ThreadPool
+from os import environ
+from unittest import SkipTest
 
 from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
@@ -32,7 +34,12 @@ class TestTreeCluster(IntegrationTestCase):
         for _ in range(self.amount_of_instances):
             run_raptiformica_command(self.temp_cache_dir, spawn_command)
 
+    def skip_if_env_override(self):
+        if environ.get('NO_NO_CONCURRENT'):
+            raise SkipTest
+
     def setUp(self):
+        self.skip_if_env_override()
         super(TestTreeCluster, self).setUp()
         self.amount_of_instances = 3
 
@@ -80,6 +87,10 @@ class TestTreeConcurrentCluster(TestTreeCluster):
     """
     workers = 3
 
+    def skip_if_env_override(self):
+        if environ.get('NO_FULL_CONCURRENT'):
+            raise SkipTest
+
     def spawn_docker_instances(self):
         spawn_command = "spawn --no-assimilate " \
                         "--server-type headless " \
@@ -98,3 +109,7 @@ class TestTreeSemiConcurrentCluster(TestTreeConcurrentCluster):
     at the same time instead of one after the other.
     """
     workers = 2
+
+    def skip_if_env_override(self):
+        if environ.get('NO_SEMI_CONCURRENT'):
+            raise SkipTest

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -101,6 +101,8 @@ class TestTreeConcurrentCluster(TestTreeCluster):
                 run_raptiformica_command,
                 args=(self.temp_cache_dir, spawn_command)
             )
+        pool.close()
+        pool.join()
 
 
 class TestTreeSemiConcurrentCluster(TestTreeConcurrentCluster):

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -1,4 +1,6 @@
-from tests.testcase import IntegrationTestCase
+from multiprocessing.pool import ThreadPool
+
+from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
 
 class TestTreeCluster(IntegrationTestCase):
@@ -24,19 +26,18 @@ class TestTreeCluster(IntegrationTestCase):
     firewall. The two public hosts (B and C) do not connect directly.
     """
     def spawn_docker_instances(self):
-        self.run_raptiformica_command(
-            "spawn --no-assimilate "
-            "--server-type headless "
-            "--compute-type docker"
-        )
+        spawn_command = "spawn --no-assimilate " \
+                        "--server-type headless " \
+                        "--compute-type docker"
+        for _ in range(self.amount_of_instances):
+            run_raptiformica_command(self.temp_cache_dir, spawn_command)
 
     def setUp(self):
         super(TestTreeCluster, self).setUp()
         self.amount_of_instances = 3
 
         # Spawn 3 un-assimilated Docker instances
-        for _ in range(self.amount_of_instances):
-            self.spawn_docker_instances()
+        self.spawn_docker_instances()
 
         # List the spawned instances and their IPs
         docker_instances = self.list_relevant_docker_instances()
@@ -50,7 +51,8 @@ class TestTreeCluster(IntegrationTestCase):
 
         # Assimilate one of the instances from the client (which is not in the cluster)
         # so we can later run raptiformica members without having to log in explicitly.
-        self.run_raptiformica_command(
+        run_raptiformica_command(
+            self.temp_cache_dir,
             "slave {} --server-type headless --verbose".format(docker_ips[0])
         )
 
@@ -69,3 +71,30 @@ class TestTreeCluster(IntegrationTestCase):
     def test_tree_cluster_establishes_mesh_correctly(self):
         self.check_consul_consensus_was_established(expected_peers=self.amount_of_instances)
         self.check_all_registered_peers_can_be_pinged_from_any_instance()
+
+
+class TestTreeConcurrentCluster(TestTreeCluster):
+    """
+    Same as the TreeCluster case but all instances boot at the same time
+    instead of one after the other.
+    """
+    workers = 3
+
+    def spawn_docker_instances(self):
+        spawn_command = "spawn --no-assimilate " \
+                        "--server-type headless " \
+                        "--compute-type docker"
+        pool = ThreadPool(self.workers)
+        for _ in range(self.amount_of_instances):
+            pool.apply_async(
+                run_raptiformica_command,
+                args=(self.temp_cache_dir, spawn_command)
+            )
+
+
+class TestTreeSemiConcurrentCluster(TestTreeConcurrentCluster):
+    """
+    Same as the TreeCluster case but all two of the three instances boot
+    at the same time instead of one after the other.
+    """
+    workers = 2

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -91,7 +91,9 @@ class IntegrationTestCase(TestCase):
     @retry(attempts=10, expect=(AssertionError,))
     def check_consul_consensus_was_established(self, expected_peers=None):
         sleep(1)
-        consul_members_output = self.run_raptiformica_command("members", buffered=True)
+        consul_members_output = run_raptiformica_command(
+            self.temp_cache_dir, "members", buffered=True
+        )
         alive_agents = consul_members_output.count("alive")
         if expected_peers is None:
             self.assertGreaterEqual(
@@ -319,7 +321,8 @@ class IntegrationTestCase(TestCase):
             )
 
     def slave_instance(self, ip_address):
-        self.run_raptiformica_command(
+        run_raptiformica_command(
+            self.temp_cache_dir,
             "slave {}".format(ip_address)
         )
 

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -23,16 +23,18 @@ class TestCase(unittest.TestCase):
         return patcher.start()
 
 
+def run_raptiformica_command(cache_dir, parameters, buffered=False):
+    raptiformica_command = "{}/bin/raptiformica {} --cache-dir {} " \
+                           "".format(conf().PROJECT_DIR.rstrip('/'),
+                                     parameters, cache_dir)
+    _, standard_out, standard_error = run_command_print_ready(
+        raptiformica_command,
+        buffered=buffered, shell=True
+    )
+    return standard_out
+
+
 class IntegrationTestCase(TestCase):
-    def run_raptiformica_command(self, parameters, buffered=False):
-        raptiformica_command = "{}/bin/raptiformica {} --cache-dir {} " \
-                               "".format(conf().PROJECT_DIR.rstrip('/'),
-                                           parameters, self.temp_cache_dir)
-        _, standard_out, standard_error = run_command_print_ready(
-            raptiformica_command,
-            buffered=buffered, shell=True
-        )
-        return standard_out
 
     def run_instance_command(self, command_as_string, buffered=False):
         """


### PR DESCRIPTION
previously the integration tests only tested all cases by booting the
instances one by one. but in real life it is often the case that
multiple nodes come online at the same time. this commit adds new test
cases for all existing integration test cases but where each node in the
test cluster is booted at the same time and where two nodes are booted
at the same time (and the third one whenever the worker finishes with
the first one of the first two).

skip the full concurrent cluster booting integration tests:
```
./runtests -1i -c
```

skip the semi concurrent cluster booting integration tests:
```
./runtests -1i -s
```

skip the serial cluster booting integration tests:
```
./runtests -1i -r
```