### PR TITLE
the default provisioner requires no source

### DIFF
--- a/modules/server/default.json
+++ b/modules/server/default.json
@@ -2,9 +2,8 @@
   "raptiformica_api_version": "0.1",
   "server": {
     "headless": {
-      "raptiformica_default_provisioner": {
-        "source": "file:///usr/share/raptiformica",
-        "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py"
+      "raptiformica": {
+        "bootstrap": "cd $HOME; export PYTHONPATH=/usr/etc/raptiformica; /usr/etc/raptiformica/modules/server/deploy.py"
       }
     }
   }

--- a/raptiformica/actions/clean.py
+++ b/raptiformica/actions/clean.py
@@ -13,7 +13,6 @@ LOCAL_STATE_DIRS = (
     '/usr/bin/consul',
     '/opt/consul',
     '/usr/etc/raptiformica',
-    '/usr/etc/raptiformica_default_provisioner',
     join(expanduser("~"), '.raptiformica.d'),
     '/root/.raptiformica.d'
 )

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -24,7 +24,7 @@ def retrieve_provisioning_configs(server_type=None):
     config = get_config()
     server_types = config[conf().KEY_VALUE_PATH]['server']
     server_type = server_types.get(server_type, {})
-    return {k: {'source': v['source'], 'bootstrap': v['bootstrap']}
+    return {k: {'source': v.get('source'), 'bootstrap': v['bootstrap']}
             for k, v in server_type.items()}
 
 
@@ -48,10 +48,11 @@ def ensure_source_on_machine(host=None, port=22, server_type=None,
     ))
     provisioning_configs = retrieve_provisioning_configs(server_type)
     for name, config in provisioning_configs.items():
-        ensure_latest_source_from_artifacts(
-            config['source'], name, host=host, port=port,
-            only_cache=only_cache
-        )
+        if config.get('source'):
+            ensure_latest_source_from_artifacts(
+                config['source'], name, host=host, port=port,
+                only_cache=only_cache
+            )
         callback(name, config)
 
 

--- a/tests/unit/raptiformica/actions/slave/test_retrieve_provisioning_configs.py
+++ b/tests/unit/raptiformica/actions/slave/test_retrieve_provisioning_configs.py
@@ -15,7 +15,8 @@ class TestRetrieveProvisioningConfigs(TestCase):
             'raptiformica.settings.load.get_config_mapping'
         )
         self.mapping = {
-            "raptiformica/compute/vagrant/headless/get_port": "cd headless && vagrant ssh-config | grep Port | awk '{print $NF}'",
+            "raptiformica/compute/vagrant/headless/get_port": "cd headless && vagrant ssh-config "
+                                                              "| grep Port | awk '{print $NF}'",
             "raptiformica/compute/vagrant/headless/source": "https://github.com/vdloo/vagrantfiles",
             "raptiformica/compute/vagrant/headless/start_instance": "cd headless && vagrant up",
             "raptiformica/server/headless/puppetfiles/bootstrap": "./papply.sh manifests/headless.pp",
@@ -46,7 +47,19 @@ class TestRetrieveProvisioningConfigs(TestCase):
                 'bootstrap': './papply.sh manifests/headless.pp',
                 'source': 'https://github.com/vdloo/puppetfiles'
             }
+        }
+        self.assertEqual(ret, expected_config)
 
+    def test_retrieve_provisioning_configs_assumes_dir_exists_if_no_source(self):
+        del self.mapping['raptiformica/server/headless/puppetfiles/source']
+
+        ret = retrieve_provisioning_configs('headless')
+
+        expected_config = {
+            'puppetfiles': {
+                'bootstrap': './papply.sh manifests/headless.pp',
+                'source': None
+            }
         }
         self.assertEqual(ret, expected_config)
 
@@ -66,7 +79,6 @@ class TestRetrieveProvisioningConfigs(TestCase):
                 'bootstrap': './deploy.sh',
                 'source': 'https://github.com/vdloo/raptiformica-map'
             }
-
         }
         self.assertEqual(ret, expected_config)
 


### PR DESCRIPTION
prevents the program from having to clone the raptiformica source into /usr/etc/raptiformica_default_provisioner additionally to /usr/etc/raptiformica. currently this was cloned from /usr/share/raptiformica but that isn't guaranteed to exist because not all hosts in the network will have raptiformica globally installed.  afaik there is also no guarantee that it will (already) exist in /usr/etc/raptiformica at the moment of cloning and there is no way to specify a relative path so it could be retrieved from the ~/.raptiformica.d/artifacts/repos dir. the idea here was that raptiformica implements its default provisioner the same way a module would, but that didn't turn out to be very convenient.