### PR TITLE
detach vagrant ssh from terminal

### DIFF
--- a/modules/compute/vagrant/raptiformica.json
+++ b/modules/compute/vagrant/raptiformica.json
@@ -6,7 +6,7 @@
         "available": "vagrant -v",
         "source": "https://github.com/vdloo/raptiformica",
         "start_instance": "cd modules/compute/vagrant && vagrant up",
-        "get_hostname": "cd modules/compute/vagrant && vagrant ssh -c 'ip addr show' 2>&1 | grep 'inet ' | tail -n 1 | awk '{print$2}' | cut -d '/' -f1",
+        "get_hostname": "cd modules/compute/vagrant && nohup vagrant ssh -c 'ip addr show' 2>&1 | grep 'inet ' | tail -n 1 | awk '{print$2}' | cut -d '/' -f1",
         "get_port": "echo 22",
         "detect_stale_instance": "cd modules/compute/vagrant && vagrant status | grep running",
         "clean_up_instance_command": "cd modules/compute/vagrant && vagrant destroy -f",


### PR DESCRIPTION
this is horrible for many reasons, but for now it will do the job.
vagrant ssh can't run in the background because it will immediately
receive a SIGTTOU. if you restart the process with a SIGCONT you will
receive another SIGTTOU immediately. this will prevent the command
from freezing even if it is detached. possible side effects: if no
terminal is available wherever this script runs a nohup.out might be
created in the future this oneliner should just become a python script
with proper parsing.

https://www.vagrantup.com/docs/cli/ssh.html#background-execution