### PR TITLE
retrieve shared secrets tries 10 times

### DIFF
--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -14,7 +14,7 @@ from raptiformica.shell.raptiformica import inject
 log = getLogger(__name__)
 
 
-def retrieve_shared_secret(service, attempts=3):
+def retrieve_shared_secret(service, attempts=10):
     """
     Retrieve the shared secret for a service from the distributed
     key value store. If it can't be retrieved or is empty, retry


### PR DESCRIPTION
only 3 times is too flaky. downside is that during bootstrapping when
there reallly is no shared config mapping yet this will wait for nothing