### PR TITLE
disable guest additions in default vagrant

### DIFF
--- a/modules/compute/vagrant/Vagrantfile
+++ b/modules/compute/vagrant/Vagrantfile
@@ -22,10 +22,7 @@ if ! File.exists?(PACKAGED_CATALOG)
 end
 
 Vagrant.configure('2') do |config|
-    if File.exists?(PACKAGED_CATALOG)
-        config.vbguest.auto_update = false
-	config.vm.synced_folder '.', '/vagrant', disabled: true
-    end
+    config.vm.synced_folder '.', '/vagrant', disabled: true
     config.tun.enabled = true
     config.ssh.forward_agent = true
     VAGRANT_SCRIPT_DIR = File.dirname(__FILE__) << '/'


### PR DESCRIPTION
causes problems when booting instances at the same time on the same
host. don't need any of the guest additions features anyway, and if in
the future it is needed then it should just be baked into the boxfile.

still restarts the box on boot to unload any previously loaded vbox
guest additions kernel module