### PR TITLE
dampen consul restarts on rejoin

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_raise_if_shared_secret_changed.py
+++ b/tests/unit/raptiformica/actions/mesh/test_raise_if_shared_secret_changed.py
@@ -1,0 +1,45 @@
+from contextlib import suppress
+
+from raptiformica.actions.mesh import raise_if_shared_secret_changed, ConsulSharedSecretChanged
+from tests.testcase import TestCase
+
+
+class TestRaiseIfSharedSecretChanged(TestCase):
+    def setUp(self):
+        self.consul_shared_secret_changed = self.set_up_patch(
+            'raptiformica.actions.mesh.consul_shared_secret_changed'
+        )
+        self.consul_shared_secret_changed.return_value = False
+        self.sleep = self.set_up_patch(
+            'raptiformica.actions.mesh.sleep'
+        )
+
+    def test_raise_if_shared_secret_changed_checks_if_shared_secret_changed(self):
+        raise_if_shared_secret_changed()
+
+        self.consul_shared_secret_changed.assert_called_once_with()
+
+    def test_raise_if_shared_secret_changed_does_not_sleep_if_not_changed(self):
+        raise_if_shared_secret_changed()
+
+        self.assertFalse(self.sleep.called)
+
+    def test_raise_if_shared_secret_changed_sleeps_for_damping_if_changed(self):
+        self.consul_shared_secret_changed.return_value = True
+
+        with suppress(ConsulSharedSecretChanged):
+            raise_if_shared_secret_changed()
+
+        self.assertEqual(self.sleep.call_count, 5)
+
+    def test_raise_if_shared_secret_changed_raises_exception_if_changed(self):
+        self.consul_shared_secret_changed.return_value = True
+
+        with self.assertRaises(ConsulSharedSecretChanged):
+            raise_if_shared_secret_changed()
+
+    def test_raise_if_shared_secret_changed_does_not_raise_if_problem_fixed_self(self):
+        self.consul_shared_secret_changed.side_effect = [True] * 4 + [False]
+
+        # Does not raise ConsulSharedSecretChanged
+        raise_if_shared_secret_changed()

--- a/tests/unit/raptiformica/actions/mesh/test_restart_consul_agent_if_necessary.py
+++ b/tests/unit/raptiformica/actions/mesh/test_restart_consul_agent_if_necessary.py
@@ -1,13 +1,13 @@
-from raptiformica.actions.mesh import restart_consul_agent_if_necessary
+from raptiformica.actions.mesh import restart_consul_agent_if_necessary, ConsulSharedSecretChanged
 from tests.testcase import TestCase
 
 
 class TestRestartConsulAgentIfNecessary(TestCase):
     def setUp(self):
-        self.consul_shared_secret_changed = self.set_up_patch(
-            'raptiformica.actions.mesh.consul_shared_secret_changed'
+        self.raise_if_shared_secret_changed = self.set_up_patch(
+            'raptiformica.actions.mesh.raise_if_shared_secret_changed'
         )
-        self.consul_shared_secret_changed.return_value = True
+        self.raise_if_shared_secret_changed.side_effect = ConsulSharedSecretChanged
         self.remove_old_consul_keyring = self.set_up_patch(
             'raptiformica.actions.mesh.remove_old_consul_keyring'
         )
@@ -18,7 +18,7 @@ class TestRestartConsulAgentIfNecessary(TestCase):
     def test_restart_consul_agent_if_necessary_checks_if_consul_shared_secret_changed(self):
         restart_consul_agent_if_necessary()
 
-        self.consul_shared_secret_changed.assert_called_once_with()
+        self.raise_if_shared_secret_changed.assert_called_once_with()
 
     def test_restart_consul_agent_if_necessary_removes_old_consul_keyring_if_shared_secret_changed(self):
         restart_consul_agent_if_necessary()
@@ -31,14 +31,14 @@ class TestRestartConsulAgentIfNecessary(TestCase):
         self.restart_consul.assert_called_once_with()
 
     def test_restart_consul_agent_if_necessary_does_not_remove_old_consul_keyring_if_no_change(self):
-        self.consul_shared_secret_changed.return_value = False
+        self.raise_if_shared_secret_changed.side_effect = None
 
         restart_consul_agent_if_necessary()
 
         self.assertFalse(self.remove_old_consul_keyring.called)
 
     def test_restart_consul_agent_if_necessary_does_not_restart_consul_if_no_change(self):
-        self.consul_shared_secret_changed.return_value = False
+        self.raise_if_shared_secret_changed.side_effect = None
 
         restart_consul_agent_if_necessary()
 


### PR DESCRIPTION
currently the rejoin seems to be causing an oscillating loop in case of scarce resources in sufficiently large clusters, this might help a bit