### PR TITLE
Revert "resource command times out after 60s"

### DIFF
--- a/raptiformica/shell/config.py
+++ b/raptiformica/shell/config.py
@@ -10,7 +10,7 @@ from raptiformica.utils import retry
 log = getLogger(__name__)
 
 
-@retry(attempts=3, expect=(RuntimeError,))
+@retry(attempts=3, expect=(RuntimeError, TimeoutError))
 def run_resource_command(command, name, host, port=22):
     """
     Run the command in a resource directory

--- a/raptiformica/shell/config.py
+++ b/raptiformica/shell/config.py
@@ -9,10 +9,8 @@ from raptiformica.utils import retry
 
 log = getLogger(__name__)
 
-RESOURCE_COMMAND_TIMEOUT = 60
 
-
-@retry(attempts=3, expect=(RuntimeError, TimeoutError))
+@retry(attempts=3, expect=(RuntimeError,))
 def run_resource_command(command, name, host, port=22):
     """
     Run the command in a resource directory
@@ -37,7 +35,6 @@ def run_resource_command(command, name, host, port=22):
             "Successfully ran resource command"
         ),
         buffered=False,
-        shell=True,
-        timeout=RESOURCE_COMMAND_TIMEOUT
+        shell=True
     )
     return exit_code

--- a/tests/unit/raptiformica/shell/config/test_run_resource_command.py
+++ b/tests/unit/raptiformica/shell/config/test_run_resource_command.py
@@ -1,4 +1,4 @@
-from raptiformica.shell.config import run_resource_command, RESOURCE_COMMAND_TIMEOUT
+from raptiformica.shell.config import run_resource_command
 from tests.testcase import TestCase
 
 
@@ -34,7 +34,7 @@ class TestRunResourceCommand(TestCase):
             expected_remote_command,
             buffered=False,
             shell=True,
-            timeout=RESOURCE_COMMAND_TIMEOUT
+            timeout=1800
         )
 
     def test_run_resource_command_returns_command_output(self):


### PR DESCRIPTION
Reverts vdloo/raptiformica#244

works but is not generic enough. inject and mesh can also get stuck like:
```
[root@hypervisor52 ~]# strace -p 22810
strace: Process 22810 attached
select(8, [3], [7], NULL, {tv_sec=4, tv_usec=639601}^Cstrace: Process 22810 detached
 <detached ...>
[root@hypervisor52 ~]# lsof -p 22810 -ad 3,7
COMMAND   PID USER   FD   TYPE   DEVICE SIZE/OFF     NODE NAME
ssh     22810 root    3u  IPv4 16451616      0t0      TCP hypervisor52:48058->172.17.0.43:ssh (ESTABLISHED)
ssh     22810 root    7w  FIFO     0,11      0t0 16453638 pipe
```
and a resource command can actually take longer than 1 minute. the ServerAliveInterval also wasn't a complete solution