### PR TITLE
disable semi-concurrent test for indirect clusters

### DIFF
--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -117,15 +117,3 @@ class TestLinkedConcurrentCluster(TestLinkedCluster):
             )
         pool.close()
         pool.join()
-
-
-class TestLinkedSemiConcurrentCluster(TestLinkedConcurrentCluster):
-    """
-    Same as the LinkedCluster case but all two of the three instances boot
-    at the same time instead of one after the other.
-    """
-    workers = 2
-
-    def skip_if_env_override(self):
-        if environ.get('NO_SEMI_CONCURRENT'):
-            raise SkipTest

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -103,15 +103,3 @@ class TestTreeConcurrentCluster(TestTreeCluster):
             )
         pool.close()
         pool.join()
-
-
-class TestTreeSemiConcurrentCluster(TestTreeConcurrentCluster):
-    """
-    Same as the TreeCluster case but all two of the three instances boot
-    at the same time instead of one after the other.
-    """
-    workers = 2
-
-    def skip_if_env_override(self):
-        if environ.get('NO_SEMI_CONCURRENT'):
-            raise SkipTest


### PR DESCRIPTION
these tests don't make sense without keeping a tunnel open to the
consul port on the first instance for the duration of the entire test.
currently the timeout of this tunnel is on 10 minutes, which may or may
not be long enough if the amount of instances to be started is more than
the amount of workers in the threadpool. when the assimilation finally
happens after all instances have been started a new connection will be
set up to an instance which might not be the first one, which will cause
the shared secret to change between instances and the cluster will fail
to establish consensus.