### PR TITLE
add socket timeout to api exceptions

### DIFF
--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -1,3 +1,4 @@
+import socket
 from contextlib import suppress, contextmanager
 from fcntl import LOCK_EX, flock, LOCK_UN
 from functools import reduce
@@ -24,7 +25,8 @@ consul_conn = Connection(
 
 API_EXCEPTIONS = (HTTPError, HTTPException, URLError,
                   ConnectionRefusedError, ConnectionResetError,
-                  BadStatusLine, OSError, ValueError)
+                  BadStatusLine, OSError, ValueError,
+                  socket.timeout)
 
 
 @contextmanager

--- a/tests/unit/raptiformica/settings/load/test_try_update_config.py
+++ b/tests/unit/raptiformica/settings/load/test_try_update_config.py
@@ -1,3 +1,4 @@
+import socket
 from urllib.error import URLError, HTTPError
 
 from mock import Mock
@@ -65,7 +66,7 @@ class TestTryUpdateConfig(TestCase):
         try_update_config_mapping(self.mapping)
 
         self.get_config.return_value.update.assert_called_once_with(
-                self.mapping
+            self.mapping
         )
 
     def test_try_update_config_updates_cached_mapping_if_connection_refused_error(self):
@@ -74,7 +75,16 @@ class TestTryUpdateConfig(TestCase):
         try_update_config_mapping(self.mapping)
 
         self.get_config.return_value.update.assert_called_once_with(
-                self.mapping
+            self.mapping
+        )
+
+    def test_try_update_config_updates_cached_mapping_if_socket_timeout(self):
+        self.update_config.side_effect = socket.timeout
+
+        try_update_config_mapping(self.mapping)
+
+        self.get_config.return_value.update.assert_called_once_with(
+            self.mapping
         )
 
     def test_try_update_config_caches_updated_mapping_if_http_error(self):


### PR DESCRIPTION
occasionally this can happen
```
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/raptiformica/tests/integration/meshnet/test_simple_cluster.py", line 51, in test_simple_cluster_establishes_mesh_correctly
    self.verify_cluster_is_operational()
  File "/var/lib/jenkins/workspace/raptiformica/tests/integration/meshnet/test_simple_cluster.py", line 47, in verify_cluster_is_operational
    self.check_data_can_be_stored_in_the_distributed_kv_store()
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/utils.py", line 145, in retry_wrapper
    return func(*args, **kwargs)
  File "/var/lib/jenkins/workspace/raptiformica/tests/testcase.py", line 200, in check_data_can_be_stored_in_the_distributed_kv_store
    upload_config_mapping({'test/some/key/in/some/path': expected_value})
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 145, in upload_config_mapping
    try_config_request(lambda: consul_conn.put_mapping(mapped))
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 134, in try_config_request
    return func()
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 145, in <lambda>
    try_config_request(lambda: consul_conn.put_mapping(mapped))
  File "/var/lib/jenkins/workspace/raptiformica/consul_kv/__init__.py", line 41, in put_mapping
    timeout=self.timeout
  File "/var/lib/jenkins/workspace/raptiformica/consul_kv/api.py", line 91, in put_kv_txn
    with request.urlopen(req, timeout=timeout) as f:
  File "/usr/lib64/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/lib64/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 1346, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib64/python3.6/urllib/request.py", line 1321, in do_open
    r = h.getresponse()
  File "/usr/lib64/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib64/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out
```