### PR TITLE
retry retrieve ipv6 address

### DIFF
--- a/raptiformica/shell/cjdns.py
+++ b/raptiformica/shell/cjdns.py
@@ -7,12 +7,14 @@ from raptiformica.shell.execute import raise_failure_factory, \
     run_critical_unbuffered_command_print_ready, run_command_print_ready, \
     run_multiple_labeled_commands
 from raptiformica.shell.git import ensure_latest_source_from_artifacts
+from raptiformica.utils import retry
 
 CJDNS_REPOSITORY = "https://github.com/vdloo/cjdns"
 
 log = getLogger(__name__)
 
 
+@retry(attempts=5, expect=(RuntimeError,))
 def get_cjdns_config_item(item, host=None, port=22):
     """
     Retrieve an item from the cjdroute.conf on a remote machine.


### PR DESCRIPTION
occasionally this can happen:
```
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/raptiformica/tests/integration/meshnet/test_linked_cluster.py", line 81, in setUp
    self.slave_from_firewalled_environment(docker_ips[0], docker_ips[:1])
  File "/var/lib/jenkins/workspace/raptiformica/tests/testcase.py", line 323, in slave_from_firewalled_environment
    "the scenario for TestTreeCluster :(".format(NATted_ip)
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 345, in run_command_print_ready
    buffered=buffered, shell=shell, timeout=timeout
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 265, in run_command
    timeout=timeout
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 184, in run_command_locally
    failure_callback(process_output)
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 278, in print_ready_callback
    callback(make_process_output_print_ready(process_output))
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 26, in raise_failure
    raise RuntimeError("{}\n{}".format(message, standard_error))
RuntimeError: Failed to slave the NATted ip 172.17.0.5. Could not set up the scenario for TestTreeCluster :(
Warning: Permanently added '172.17.0.5' (ECDSA) to the list of known hosts.
Traceback (most recent call last):
  File "/usr/share/raptiformica/bin/raptiformica_slave.py", line 5, in <module>
    slave()
  File "/usr/share/raptiformica/raptiformica/cli.py", line 86, in slave
    server_type=args.server_type
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 130, in slave_machine
    assimilate_machine(host, port=port, uuid=uuid)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 88, in assimilate_machine
    ensure_route_to_new_neighbour(host, port=port, compute_checkout_uuid=uuid)
  File "/usr/share/raptiformica/raptiformica/settings/meshnet.py", line 188, in ensure_route_to_new_neighbour
    host, port=port, compute_checkout_uuid=compute_checkout_uuid
  File "/usr/share/raptiformica/raptiformica/settings/meshnet.py", line 148, in update_meshnet_config
    host, port=port, uuid=compute_checkout_uuid
  File "/usr/share/raptiformica/raptiformica/settings/meshnet.py", line 111, in update_neighbours_config
    cjdns_ipv6_address = cjdns.get_ipv6_address(host, port=port)
  File "/usr/share/raptiformica/raptiformica/shell/cjdns.py", line 65, in get_ipv6_address
    return get_cjdns_config_item('ipv6', host=host, port=port)
  File "/usr/share/raptiformica/raptiformica/shell/cjdns.py", line 36, in get_cjdns_config_item
    "from {}".format(item, host)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 345, in run_command_print_ready
    buffered=buffered, shell=shell, timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 257, in run_command
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 226, in run_command_remotely
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 184, in run_command_locally
    failure_callback(process_output)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 278, in print_ready_callback
    callback(make_process_output_print_ready(process_output))
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 26, in raise_failure
    raise RuntimeError("{}
{}".format(message, standard_error))
RuntimeError: Failed to retrieve CJDNS ipv6 from 172.17.0.5
Warning: Permanently added '172.17.0.5' (ECDSA) to the list of known hosts.
```