### PR TITLE
install requirements in vagrant provisioning

### DIFF
--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -4,8 +4,7 @@ echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer
 
 pacman -Sy archlinux-keyring --noconfirm --needed
 pacman -Sy --noconfirm
-pacman -S ruby git puppet --noconfirm --needed
-pacman -S acl --noconfirm --needed
+pacman -S ruby git puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
 
 # Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
 # yet again before docker will work inside the virtualized guest due to the right veth kernel module 


### PR DESCRIPTION
eventually installing the dependencies will have to be abstracted out
and exposed as an extra hook in the assimilation process. then it will
be optional to have raptiformica install the requirements on the go and
the chance of package manager locking issues will be minimized.