### PR TITLE
retry pull origin master if times out

### DIFF
--- a/raptiformica/shell/git.py
+++ b/raptiformica/shell/git.py
@@ -7,7 +7,7 @@ from os.path import join
 from raptiformica.settings import conf, Config
 from raptiformica.shell.execute import run_command_print_ready, \
     log_failure_factory, run_command
-from raptiformica.utils import ensure_directory
+from raptiformica.utils import ensure_directory, retry
 
 log = getLogger(__name__)
 
@@ -49,6 +49,7 @@ def clone_source(url, directory, host=None, port=22):
     )
 
 
+@retry(attempts=3, expect=(TimeoutError,))
 def pull_origin_master(directory, host=None, port=22):
     """
     Pull origin master in a directory on the remote machine


### PR DESCRIPTION
if the network is slow or the system is starved of IO, it could help to
retry the git pull origin master again and it does not harm to do so
because it is idempotent

```
Exception in thread Thread-12:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 1180, in run
    self.function(*self.args, **self.kwargs)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 97, in terminate_and_kill
    "Command was: {}".format(timeout, command)
TimeoutError: Subprocess timed out after 180 seconds. Command was: cd /home/jenkins/.raptiformica.d/artifacts/repositories/cjdns; git pull origin master
```