### PR TITLE
do not install puppet modules

### DIFF
--- a/modules/compute/docker/Dockerfile
+++ b/modules/compute/docker/Dockerfile
@@ -6,7 +6,6 @@ ADD instance_key.pub /tmp/instance_key.pub
 RUN cat /tmp/instance_key.pub > /root/.ssh/authorized_keys && rm -f /tmp/instance_key.pub
 RUN apt-get update && apt-get install -y \
     rsync \
-    puppet \
     htop \
     nodejs \
     build-essential \
@@ -17,7 +16,4 @@ RUN apt-get update && apt-get install -y \
     unzip \
     screen \
     git
-RUN puppet module install puppetlabs-vcsrepo
-RUN puppet module install maestrodev-wget
-RUN puppet module install saz-sudo
 

--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -4,7 +4,7 @@ echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer
 
 pacman -Sy archlinux-keyring --noconfirm --needed
 pacman -Sy --noconfirm
-pacman -S ruby git puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
+pacman -S ruby git acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
 
 # Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
 # yet again before docker will work inside the virtualized guest due to the right veth kernel module 

--- a/modules/compute/vagrant/provision.sh
+++ b/modules/compute/vagrant/provision.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env sh
 userdel terry --force || /bin/true  # remove image maintainer's user
-puppet module install puppetlabs-vcsrepo
-puppet module install maestrodev-wget
-puppet module install saz-sudo
 
 # make sure the keys from the ssh agent can log in as root
 mkdir -p /root/.ssh/

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -426,7 +426,7 @@ def parse_install_arguments():
     parser.add_argument(
         'name', type=str,
         help='Name of the module to load or '
-             'unload. Like "vdloo/puppetfiles"'
+             'unload. Like "vdloo/raptiformica-map"'
     )
     parser.add_argument(
         '--remove', '-r', action='store_true',

--- a/tests/unit/raptiformica/cli/test_parse_install_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_install_arguments.py
@@ -25,7 +25,7 @@ class TestParseInstallArguments(TestCase):
                 'name',
                 type=str,
                 help='Name of the module to load or unload. '
-                     'Like "vdloo/puppetfiles"'
+                     'Like "vdloo/raptiformica-map"'
             ),
             call(
                 '--remove', '-r', action='store_true',


### PR DESCRIPTION
configuration management should not be part of raptiformica anymore but
belongs in the space of the modules that are installed as raptiformica
modules, so for example vdloo/simulacra will start a jobrunner that will
run the configuration management or vdloo/raptiformica-map which runs
configuration management in a screen detached from the main assimilation
process. this will decouple the overlay network from configuration
management and installing any requirements. breaks vdloo/puppetfiles for
the default vagrant and docker developent instances.