### PR TITLE
Register self in agent

### DIFF
--- a/bin/raptiformica
+++ b/bin/raptiformica
@@ -12,6 +12,7 @@ INSTALL_ENTRYPOINT="raptiformica_install.py"
 SSH_ENTRYPOINT="raptiformica_ssh.py"
 INJECT_ENTRYPOINT="raptiformica_inject.py"
 CLEAN_ENTRYPOINT="raptiformica_clean.py"
+ADVERTISE_ENTRYPOINT="raptiformica_advertise.py"
 
 function print_help {
     cat <<'END'
@@ -46,6 +47,9 @@ Usage: raptiformica [CMD..] [OPTIONS] [-h]
 
   clean                      Remove all state on the local 
                              machine if any.
+
+  advertise                  Set the host and port to advertise
+                             on the local machine.
 END
 }
 
@@ -92,6 +96,10 @@ case $1 in
     ;;
     clean)
     RAPTIFORMICA_CMD=$CLEAN_ENTRYPOINT
+    shift
+    ;;
+    advertise)
+    RAPTIFORMICA_CMD=$ADVERTISE_ENTRYPOINT
     shift
     ;;
     *)

--- a/bin/raptiformica_advertise.py
+++ b/bin/raptiformica_advertise.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+from raptiformica.cli import advertise
+
+if __name__ == '__main__':
+    advertise()
+else:
+    raise RuntimeError("This script is an entry point and can not be imported")

--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -14,6 +14,7 @@ from os import path
 
 from raptiformica.settings import conf
 from raptiformica.settings.load import get_config_mapping
+from raptiformica.settings.meshnet import update_neighbours_config
 from raptiformica.shell.execute import run_command_print_ready, run_command, check_nonzero_exit, \
     log_failure_factory, raise_failure_factory
 from raptiformica.shell.hooks import fire_hooks
@@ -877,6 +878,7 @@ def attempt_join_meshnet():
     :return None:
     """
     log.info("Joining the machine into the distributed network")
+    update_neighbours_config(remove=False)
     configure_meshing_services()
     start_meshing_services()
     # todo: in the future, if there are not enough neighbours to bootstrap

--- a/raptiformica/actions/slave.py
+++ b/raptiformica/actions/slave.py
@@ -7,7 +7,7 @@ from raptiformica.settings.types import get_first_server_type
 from raptiformica.shell.config import run_resource_command
 from raptiformica.shell.git import ensure_latest_source_from_artifacts
 from raptiformica.shell.hooks import fire_hooks
-from raptiformica.shell.raptiformica import mesh
+from raptiformica.shell.raptiformica import mesh, advertise
 from raptiformica.shell.rsync import upload_self, download_artifacts
 
 log = getLogger(__name__)
@@ -85,6 +85,7 @@ def assimilate_machine(host, port=22, uuid=None):
     """
     log.info("Preparing to machine to be joined into the distributed network")
     download_artifacts(host, port=port)
+    advertise(host, port=port)
     ensure_route_to_new_neighbour(host, port=port, compute_checkout_uuid=uuid)
 
 

--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -17,7 +17,7 @@ from raptiformica.actions.spawn import spawn_machine
 from raptiformica.actions.ssh_connect import ssh_connect
 from raptiformica.log import setup_logging
 from raptiformica.settings import conf
-from raptiformica.settings.meshnet import update_meshnet_config
+from raptiformica.settings.meshnet import update_meshnet_config, write_last_advertised
 from raptiformica.settings.types import get_server_types, \
     get_first_server_type, get_first_compute_type, get_compute_types
 
@@ -466,3 +466,29 @@ def clean():
     """
     parse_clean_arguments()
     clean_local_state()
+
+
+def parse_advertise_arguments():
+    """
+    Parse the commandline options for advertising a host and port on
+    the local machine.
+    :return obj args: parsed arguments
+    """
+    parser = ArgumentParser(
+        prog="raptiformica advertise",
+        description="Set the host and port to advertise on the local machine"
+    )
+    parser.add_argument('host', type=str,
+                        help='The host to advertise')
+    parser.add_argument('--port', '-p', type=int, default=22,
+                        help='The port to advertise')
+    return parse_arguments(parser)
+
+
+def advertise():
+    """
+    Set the host and port to advertise on the local machine
+    :return None:
+    """
+    args = parse_advertise_arguments()
+    write_last_advertised(args.host, args.port)

--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -14,6 +14,7 @@ class Config(object):
     MACHINES_DIR = join(EPHEMERAL_DIR, 'machines')
     BASE_CONFIG = join(PROJECT_DIR, '.base_config.json')
     MUTABLE_CONFIG = join(ABS_CACHE_DIR, 'mutable_config.json')
+    LAST_ADVERTISED = join(ABS_CACHE_DIR, 'last_advertised')
     CONFIG_CACHE_LOCK = '/tmp/raptiformica_config_cache.lock'
     PACKAGE_MANGER_UPDATED = '/tmp/raptiformica_last_updated_package_manager'
     PACKAGE_MANAGER_CACHE_OUTDATED = 600
@@ -38,6 +39,7 @@ class Config(object):
         self.ABS_CACHE_DIR = join(expanduser("~"), self.CACHE_DIR)
         self.EPHEMERAL_DIR = join(self.ABS_CACHE_DIR, 'var')
         self.MUTABLE_CONFIG = join(self.ABS_CACHE_DIR, 'mutable_config.json')
+        self.LAST_ADVERTISED = join(self.ABS_CACHE_DIR, 'last_advertised')
         self.MACHINES_DIR = join(self.EPHEMERAL_DIR, 'machines')
         self.USER_MODULES_DIR = join(self.ABS_CACHE_DIR, 'modules')
         self.USER_ARTIFACTS_DIR = join(self.ABS_CACHE_DIR, 'artifacts')

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -97,7 +97,15 @@ def update_consul_config():
     return ensure_shared_secret('consul')
 
 
-def update_neighbours_config(host, port=22, uuid=None):
+def get_last_advertised():
+    """
+    Return the last advertised host name for this machine
+    :return None:
+    """
+    pass
+
+
+def update_neighbours_config(host=None, port=22, uuid=None, remove=True):
     """
     Update the neighbours config in the k v mapping
     - update the distributed key value store with the neighbour
@@ -105,11 +113,14 @@ def update_neighbours_config(host, port=22, uuid=None):
     :param str host: hostname or ip of the remote machine
     :param int port: port to use to connect to the remote machine over ssh
     :param str uuid: identifier for a local compute checkout
+    :param bool remove: Ensure neighbour with hostname is removed
+    from the config first before adding.
     :return dict mapping: the updated config mapping
     """
     cjdns_public_key = cjdns.get_public_key(host, port=port)
     cjdns_ipv6_address = cjdns.get_ipv6_address(host, port=port)
 
+    host = host or get_last_advertised()
     neighbour_entry = {
         'host': host,
         'cjdns_port': str(conf().CJDNS_DEFAULT_PORT),
@@ -127,7 +138,8 @@ def update_neighbours_config(host, port=22, uuid=None):
     neighbour_mapping = {
         join(neighbour_path, k): v for k, v in neighbour_entry.items()
     }
-    ensure_neighbour_removed_from_config_by_host(host)
+    if remove:
+        ensure_neighbour_removed_from_config_by_host(host)
     return try_update_config_mapping(neighbour_mapping)
 
 

--- a/raptiformica/settings/meshnet.py
+++ b/raptiformica/settings/meshnet.py
@@ -112,15 +112,8 @@ def write_last_advertised(host, port):
     :param int port: port to use to connect to the remote machine over ssh
     :return dict:
     """
-    last_advertised_data = {
-        'host': host,
-        'port': port
-    }
+    last_advertised_data = {'host': host, 'port': port}
     write_json(last_advertised_data, conf().LAST_ADVERTISED)
-
-    with open(conf().LAST_ADVERTISED, 'w') as f:
-        f.write(host)
-        return f.read().strip()
 
 
 def update_neighbours_config(host=None, port=22, uuid=None, remove=True):

--- a/raptiformica/shell/raptiformica.py
+++ b/raptiformica/shell/raptiformica.py
@@ -49,6 +49,28 @@ def run_raptiformica_command(command_as_string, host, port=22):
     return exit_code
 
 
+def advertise(host, port=22):
+    """
+    Run ./bin/raptiformica_advertise.py on a remote machine.
+    Sets the last advertised information on the remote host.
+    With this data the remote host can re-register itself
+    later in case the update_neighbours_config fails in the
+    local process on the machine that is assimilating the
+    remote host.
+    :param str host: hostname or ip of the remote machine
+    :param int port: port to use to connect to the remote machine over ssh
+    :return int exit_code: Exit code from the ./bin/raptiformica_mesh.py command
+    """
+    log.info("Setting the host and port to advertise on the remote host")
+    # todo: let the remote raptiformica command use the same logging level
+    # as the current process
+    return run_raptiformica_command(
+        "export PYTHONPATH=.; ./bin/raptiformica_advertise.py "
+        "{} --port {}".format(host, port),
+        host, port=port
+    )
+
+
 def mesh(host, port=22, after_mesh=True):
     """
     Run ./bin/raptiformica_mesh.py on a remote machine.

--- a/tests/unit/raptiformica/actions/mesh/test_attempt_join_meshnet.py
+++ b/tests/unit/raptiformica/actions/mesh/test_attempt_join_meshnet.py
@@ -5,6 +5,9 @@ from tests.testcase import TestCase
 class TestAttemptJoinMeshnet(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.update_neighbours_config = self.set_up_patch(
+            'raptiformica.actions.mesh.update_neighbours_config'
+        )
         self.configure_meshing_services = self.set_up_patch(
             'raptiformica.actions.mesh.configure_meshing_services'
         )
@@ -18,6 +21,11 @@ class TestAttemptJoinMeshnet(TestCase):
         attempt_join_meshnet()
 
         self.assertTrue(self.log.info.called)
+
+    def test_attempt_join_meshnet_updates_neighbour_config_to_ensure_self_is_registered(self):
+        attempt_join_meshnet()
+
+        self.update_neighbours_config.assert_called_once_with(remove=False)
 
     def test_attempt_join_meshnet_configures_meshing_services(self):
         attempt_join_meshnet()

--- a/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
+++ b/tests/unit/raptiformica/actions/slave/test_assimilate_machine.py
@@ -6,6 +6,7 @@ class TestAssimilateMachine(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.slave.log')
         self.download_artifacts = self.set_up_patch('raptiformica.actions.slave.download_artifacts')
+        self.advertise = self.set_up_patch('raptiformica.actions.slave.advertise')
         self.ensure_route_to_new_neighbour = self.set_up_patch(
             'raptiformica.actions.slave.ensure_route_to_new_neighbour'
         )
@@ -19,6 +20,11 @@ class TestAssimilateMachine(TestCase):
         assimilate_machine('1.2.3.4', port=2222)
 
         self.download_artifacts.assert_called_once_with('1.2.3.4', port=2222)
+
+    def test_assimilate_machine_sets_advertised_host_and_port_on_remote_machine(self):
+        assimilate_machine('1.2.3.4', port=2222)
+
+        self.advertise.assert_called_once_with('1.2.3.4', port=2222)
 
     def test_assimilate_machine_ensures_route_to_new_neighbour(self):
         assimilate_machine('1.2.3.4', port=2222)

--- a/tests/unit/raptiformica/cli/test_advertise.py
+++ b/tests/unit/raptiformica/cli/test_advertise.py
@@ -1,0 +1,25 @@
+from raptiformica.cli import advertise
+from tests.testcase import TestCase
+
+
+class TestAdvertise(TestCase):
+    def setUp(self):
+        self.parse_advertise_arguments = self.set_up_patch(
+            'raptiformica.cli.parse_advertise_arguments'
+        )
+        self.write_last_advertised = self.set_up_patch(
+            'raptiformica.cli.write_last_advertised'
+        )
+
+    def test_advertise_parses_advertise_arguments(self):
+        advertise()
+
+        self.parse_advertise_arguments.assert_called_once_with()
+
+    def test_advertise_writes_last_advertised(self):
+        advertise()
+
+        self.write_last_advertised.assert_called_once_with(
+            self.parse_advertise_arguments.return_value.host,
+            self.parse_advertise_arguments.return_value.port
+        )

--- a/tests/unit/raptiformica/cli/test_parse_advertise_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_advertise_arguments.py
@@ -1,0 +1,43 @@
+from mock import call
+
+from raptiformica.cli import parse_advertise_arguments
+from tests.testcase import TestCase
+
+
+class TestParseAdvertiseArguments(TestCase):
+    def setUp(self):
+        self.argument_parser = self.set_up_patch('raptiformica.cli.ArgumentParser')
+        self.parse_arguments = self.set_up_patch('raptiformica.cli.parse_arguments')
+
+    def test_parse_advertise_arguments_instantiates_argparser(self):
+        parse_advertise_arguments()
+
+        self.argument_parser.assert_called_once_with(
+            prog='raptiformica advertise',
+            description="Set the host and port to advertise on the local machine"
+        )
+
+    def test_parse_advertise_arguments_adds_arguments(self):
+        parse_advertise_arguments()
+
+        expected_calls = [
+            call('host', type=str, help='The host to advertise'),
+            call(
+                '--port', '-p', type=int, default=22,
+                help='The port to advertise'
+            )
+        ]
+        self.assertEqual(
+            self.argument_parser.return_value.add_argument.mock_calls,
+            expected_calls
+        )
+
+    def test_parse_advertise_arguments_parses_arguments(self):
+        parse_advertise_arguments()
+
+        self.parse_arguments.assert_called_once_with(self.argument_parser.return_value)
+
+    def test_parse_advertise_arguments_returns_parsed_arguments(self):
+        ret = parse_advertise_arguments()
+
+        self.assertEqual(ret, self.parse_arguments.return_value)

--- a/tests/unit/raptiformica/settings/meshnet/test_get_last_advertised.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_get_last_advertised.py
@@ -1,0 +1,22 @@
+from raptiformica.settings import conf
+from raptiformica.settings.meshnet import get_last_advertised
+from tests.testcase import TestCase
+
+
+class TestGetLastAdvertised(TestCase):
+    def setUp(self):
+        self.load_json = self.set_up_patch(
+            'raptiformica.settings.meshnet.load_json'
+        )
+
+    def test_get_last_advertised_loads_last_advertised_json(self):
+        get_last_advertised()
+
+        self.load_json.assert_called_once_with(
+            conf().LAST_ADVERTISED
+        )
+
+    def test_get_last_advertised_returns_last_advertised_json(self):
+        ret = get_last_advertised()
+
+        self.assertEqual(ret, self.load_json.return_value)

--- a/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
@@ -5,6 +5,10 @@ from tests.testcase import TestCase
 class TestUpdateNeighboursConfig(TestCase):
     def setUp(self):
         self.cjdns = self.set_up_patch('raptiformica.settings.meshnet.cjdns')
+        self.get_last_advertised = self.set_up_patch(
+            'raptiformica.settings.meshnet.get_last_advertised',
+            return_value='1.2.3.5'
+        )
         self.cjdns.get_public_key.return_value = 'a_public_key.k'
         self.cjdns.get_ipv6_address.return_value = 'ipv6_address'
         self.config = {'meshnet': {'neighbours': {}}}
@@ -20,16 +24,40 @@ class TestUpdateNeighboursConfig(TestCase):
 
         self.cjdns.get_public_key.assert_called_once_with('1.2.3.4', port=2222)
 
+    def test_update_neighbours_config_gets_cjdns_public_key_from_local_host(self):
+        update_neighbours_config()
+
+        self.cjdns.get_public_key.assert_called_once_with(None, port=22)
+
     def test_update_neighbours_config_gets_cjdns_ipv6_address_from_remote_host(self):
         update_neighbours_config('1.2.3.4', port=2222)
 
         self.cjdns.get_ipv6_address.assert_called_once_with('1.2.3.4', port=2222)
+
+    def test_update_neighbours_config_gets_cjdns_ipv6_address_from_local_host(self):
+        update_neighbours_config()
+
+        self.cjdns.get_ipv6_address.assert_called_once_with(None, port=22)
 
     def test_update_neighbours_config_removes_entries_for_the_updated_host(self):
         update_neighbours_config('1.2.3.4', port=2222)
 
         self.ensure_neighbour_removed_from_config_by_host.assert_called_once_with(
             '1.2.3.4'
+        )
+
+    def test_update_neighbours_config_removes_entries_for_the_local_host(self):
+        update_neighbours_config()
+
+        self.ensure_neighbour_removed_from_config_by_host.assert_called_once_with(
+            '1.2.3.5'
+        )
+
+    def test_update_neighbours_config_does_not_remove_entries_if_specified(self):
+        update_neighbours_config(remove=False)
+
+        self.assertFalse(
+            self.ensure_neighbour_removed_from_config_by_host.called
         )
 
     def test_update_neighbours_config_returns_updated_config(self):
@@ -43,6 +71,22 @@ class TestUpdateNeighboursConfig(TestCase):
             'raptiformica/meshnet/neighbours/a_public_key.k/ssh_port': "2222"
 
         }
+        self.assertFalse(self.get_last_advertised.called)
+        self.try_update_config.assert_called_once_with(expected_config)
+        self.assertEqual(ret, self.try_update_config.return_value)
+
+    def test_update_neighbours_retrieves_last_advertised_if_no_host_specified(self):
+        ret = update_neighbours_config()
+
+        expected_config = {
+            'raptiformica/meshnet/neighbours/a_public_key.k/cjdns_ipv6_address': 'ipv6_address',
+            'raptiformica/meshnet/neighbours/a_public_key.k/cjdns_port': "4863",
+            'raptiformica/meshnet/neighbours/a_public_key.k/cjdns_public_key': 'a_public_key.k',
+            'raptiformica/meshnet/neighbours/a_public_key.k/host': '1.2.3.5',
+            'raptiformica/meshnet/neighbours/a_public_key.k/ssh_port': "22"
+
+        }
+        self.get_last_advertised.assert_called_once_with()
         self.try_update_config.assert_called_once_with(expected_config)
         self.assertEqual(ret, self.try_update_config.return_value)
 

--- a/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_update_neighbours_config.py
@@ -7,7 +7,7 @@ class TestUpdateNeighboursConfig(TestCase):
         self.cjdns = self.set_up_patch('raptiformica.settings.meshnet.cjdns')
         self.get_last_advertised = self.set_up_patch(
             'raptiformica.settings.meshnet.get_last_advertised',
-            return_value='1.2.3.5'
+            return_value={'port': 22, 'host': '1.2.3.5'}
         )
         self.cjdns.get_public_key.return_value = 'a_public_key.k'
         self.cjdns.get_ipv6_address.return_value = 'ipv6_address'

--- a/tests/unit/raptiformica/settings/meshnet/test_write_last_advertised.py
+++ b/tests/unit/raptiformica/settings/meshnet/test_write_last_advertised.py
@@ -1,0 +1,21 @@
+from raptiformica.settings import conf
+from raptiformica.settings.meshnet import write_last_advertised
+from tests.testcase import TestCase
+
+
+class TestWriteLastAdvertised(TestCase):
+    def setUp(self):
+        self.write_json = self.set_up_patch(
+            'raptiformica.settings.meshnet.write_json'
+        )
+
+    def test_write_last_advertised_writes_last_advertised_json(self):
+        write_last_advertised('1.2.3.4', 22)
+
+        expected_last_advertised_data = {
+            'host': '1.2.3.4', 'port': 22
+        }
+        self.write_json.assert_called_once_with(
+            expected_last_advertised_data,
+            conf().LAST_ADVERTISED
+        )

--- a/tests/unit/raptiformica/shell/raptiformica/test_advertise.py
+++ b/tests/unit/raptiformica/shell/raptiformica/test_advertise.py
@@ -1,0 +1,28 @@
+from raptiformica.shell.raptiformica import advertise
+from tests.testcase import TestCase
+
+
+class TestAdvertise(TestCase):
+    def setUp(self):
+        self.log = self.set_up_patch('raptiformica.shell.raptiformica.log')
+        self.run_raptiformica_command = self.set_up_patch(
+            'raptiformica.shell.raptiformica.run_raptiformica_command'
+        )
+
+    def test_advertise_logs_advertise_message(self):
+        advertise('1.2.3.4', port=2222)
+
+        self.assertTrue(self.log.info.called)
+
+    def test_advertise_runs_raptiformica_command(self):
+        advertise('1.2.3.4', port=2222)
+
+        self.run_raptiformica_command.assert_called_once_with(
+            'export PYTHONPATH=.; ./bin/raptiformica_advertise.py '
+            '1.2.3.4 --port 2222', '1.2.3.4', port=2222
+        )
+
+    def test_advertise_returns_raptiformica_command_exit_code(self):
+        ret = advertise('1.2.3.4', port=2222)
+
+        self.assertEqual(ret, self.run_raptiformica_command.return_value)


### PR DESCRIPTION
looks like there is an issue with centrality if the cluster is sufficiently unstable. if instances can't be registered during the initial assimilation there is no mechanism that will retry later, the instance will only be registered in the local mutable config which will be overwritten by more recent state as soon as consensus returns, all other nodes will not know how to find the new machine.


![centrality](https://user-images.githubusercontent.com/1437341/30786031-fab7ba84-a16f-11e7-917d-7c7f5c7c4874.png)
![centrality2](https://user-images.githubusercontent.com/1437341/30786033-ff7a0cf2-a16f-11e7-9b46-38f19a500042.png)

will partly be mitigated by https://github.com/vdloo/raptiformica/pull/261 and https://github.com/vdloo/raptiformica/pull/262 but it would be nicer if the system could ensure that each instance will try to self register when stability has returned as part of the raptiformica agent loop
