### PR TITLE
pick random peers

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -18,7 +18,7 @@ from raptiformica.shell.execute import run_command_print_ready, run_command, che
     log_failure_factory, raise_failure_factory
 from raptiformica.shell.hooks import fire_hooks
 from raptiformica.utils import load_json, write_json, ensure_directory, startswith, wait, group_n_elements, \
-    calculate_checksum, retry
+    calculate_checksum, retry, calculate_lines_checksum
 
 log = getLogger(__name__)
 
@@ -122,6 +122,7 @@ def configure_cjdroute_conf():
         'password': cjdns_secret,
     }]
     neighbours = parse_cjdns_neighbours(mapping)
+    shuffle(neighbours)
     cjdroute_config['interfaces']['UDPInterface'] = [{
         'connectTo': neighbours,
         'bind': '0.0.0.0:{}'.format(conf().CJDNS_DEFAULT_PORT)
@@ -466,7 +467,7 @@ def cjdroute_config_hash_outdated():
         with open(CJDROUTE_CONF_HASH, 'rb') as config_hash_file:
             binary_stored_hash = config_hash_file.read()
             stored_hash = binary_stored_hash.decode('utf-8')
-        return stored_hash != calculate_checksum(CJDROUTE_CONF_PATH)
+        return stored_hash != calculate_lines_checksum(CJDROUTE_CONF_PATH)
     else:
         # There is no config hash yet so it is not up to
         # date because it does not exist
@@ -485,7 +486,7 @@ def write_cjdroute_config_hash():
         "we can only reload when we have to"
     )
     with open(CJDROUTE_CONF_HASH, 'wb') as config_hash_file:
-        config_hash = calculate_checksum(CJDROUTE_CONF_PATH)
+        config_hash = calculate_lines_checksum(CJDROUTE_CONF_PATH)
         binary_config_hash = config_hash.encode('utf-8')
         config_hash_file.write(binary_config_hash)
 

--- a/raptiformica/utils.py
+++ b/raptiformica/utils.py
@@ -177,6 +177,7 @@ def calculate_checksum(filename):
     """
     Calculate the sha1 checksum of a file (in chunks)
     :param str filename: The file to calculate the checksum of
+    :param bool any_order: Sort lines before checksumming
     :return str checksum: The calculated checksum
     """
     file_hash = hashlib.sha1()
@@ -185,6 +186,21 @@ def calculate_checksum(filename):
         while len(buf) > 0:
             file_hash.update(buf)
             buf = f.read(128)
+        return file_hash.hexdigest()
+
+
+def calculate_lines_checksum(filename):
+    """
+    Calculate the sha1 checksum of a textfile, lines are sorted
+    before checksumming.
+    :param str filename: The file to calculate the checksum of
+    :return str checksum: The calculated checksum
+    """
+    file_hash = hashlib.sha1()
+    with open(filename, 'rb') as f:
+        lines = f.readlines()
+        sorted_lines = sorted(lines)
+        file_hash.update(b'\n'.join(sorted_lines))
         return file_hash.hexdigest()
 
 

--- a/tests/unit/raptiformica/actions/mesh/test_cjdroute_config_hash_outdated.py
+++ b/tests/unit/raptiformica/actions/mesh/test_cjdroute_config_hash_outdated.py
@@ -17,9 +17,11 @@ class TestCjdrouteConfigHashOutdated(TestCase):
         self.set_up_patch(
             'raptiformica.actions.mesh.CJDROUTE_CONF_PATH', self.cjdroute_config_file.name
         )
+        self.uuid1, self.uuid2 = uuid4(), uuid4()
+        self.uuid2 = uuid4()
         self.cjdroute_config_file.write(
             # Write a random bytestring to the config file
-            str(uuid4).encode('utf-8')
+            "{}\n{}\n".format(self.uuid1, self.uuid2).encode('utf-8')
         )
         self.cjdroute_config_file.flush()
 
@@ -42,13 +44,30 @@ class TestCjdrouteConfigHashOutdated(TestCase):
 
         self.assertFalse(ret)
 
+    def test_cjdroute_config_hash_outdated_returns_false_if_hash_still_up_to_date_any_order(self):
+        write_cjdroute_config_hash()
+
+        cjdroute_config_file = NamedTemporaryFile()
+        self.set_up_patch(
+            'raptiformica.actions.mesh.CJDROUTE_CONF_PATH', cjdroute_config_file.name
+        )
+        cjdroute_config_file.write(
+            # Write the same bytestring but with lines in other order
+            "{}\n{}\n".format(self.uuid2, self.uuid1).encode('utf-8')
+        )
+        cjdroute_config_file.flush()
+
+        ret = cjdroute_config_hash_outdated()
+
+        self.assertFalse(ret)
+
     def test_cjdroute_config_hash_outdated_returns_true_if_hash_no_longer_up_to_date(self):
         write_cjdroute_config_hash()
 
         self.cjdroute_config_file.write(
             # Write a random bytestring to the config file
             # again so the hash is no longer up to date
-            str(uuid4).encode('utf-8')
+            "{}\n{}".format(uuid4(), uuid4()).encode('utf-8')
         )
         self.cjdroute_config_file.flush()
 

--- a/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
+++ b/tests/unit/raptiformica/actions/mesh/test_configure_cjdroute_conf.py
@@ -7,6 +7,7 @@ from tests.testcase import TestCase
 class TestConfigureCjdrouteConf(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.shuffle = self.set_up_patch('raptiformica.actions.mesh.shuffle')
         self.mapping = {
             "raptiformica/meshnet/cjdns/password": "a_secret",
             "raptiformica/meshnet/consul/password": "a_different_secret",
@@ -63,6 +64,25 @@ class TestConfigureCjdrouteConf(TestCase):
 
         with self.assertRaises(ValueError):
             configure_cjdroute_conf()
+
+    def test_configure_cjdroute_conf_shuffles_neighbours(self):
+        expected_neighbours = {
+            '192.168.178.23:4863': {
+                'peerName': '192.168.178.23:4863',
+                'publicKey': 'a_pubkey.k',
+                'password': 'a_secret'
+            },
+            '192.168.178.24:4863': {
+                'peerName': '192.168.178.24:4863',
+                'publicKey': 'a_different_pubkey.k',
+                'password': 'a_secret'
+            }
+        }
+        configure_cjdroute_conf()
+
+        self.shuffle.assert_called_once_with(
+            expected_neighbours
+        )
 
     def test_configure_cjdroute_conf_writes_cjdroute_config_to_disk(self):
         configure_cjdroute_conf()


### PR DESCRIPTION
should decrease centrality. otherwise the first 7 nodes will be connected to from all instances always

- pick random peers
- hash sorted lines of config file instead of config file (so it can be
  shuffled without going stale very shuffle)