### PR TITLE
block until enough relevant instances found

### DIFF
--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -45,7 +45,7 @@ class TestLinkedCluster(IntegrationTestCase):
         self.spawn_docker_instances()
 
         # List the spawned instances and their IPs
-        docker_instances = self.list_relevant_docker_instances()
+        docker_instances = self.list_relevant_docker_instances(self.amount_of_instances)
         docker_ips = list(map(self.get_docker_ip, docker_instances))
 
         # Ensure the requirements are installed

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -47,7 +47,7 @@ class TestTreeCluster(IntegrationTestCase):
         self.spawn_docker_instances()
 
         # List the spawned instances and their IPs
-        docker_instances = self.list_relevant_docker_instances()
+        docker_instances = self.list_relevant_docker_instances(expected=self.amount_of_instances)
         docker_ips = list(map(self.get_docker_ip, docker_instances))
 
         # Ensure the requirements are installed


### PR DESCRIPTION
in integration tests