### PR TITLE
kill all dockers between tests

### DIFF
--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -60,7 +60,7 @@ class IntegrationTestCase(TestCase):
         return standard_out
 
     def kill_all_dockers(self):
-        dockers_to_kill = self.list_relevant_docker_instances(expected=0)
+        dockers_to_kill = self.list_docker_instances()
         kill_all_dockers_command = "echo {} | " \
                                    "sudo xargs --no-run-if-empty docker " \
                                    "kill".format(' '.join(dockers_to_kill))


### PR DESCRIPTION
the shared secret might not exist in all dockers that we need to kill.
to isolate testruns this will later have to be reverted and something
else will need to be used to track which dockers belong to this testrun
because checking the shared secret is not a complete solution