### PR TITLE
create shared secret before concurrent tests

### DIFF
--- a/tests/integration/meshnet/test_linked_cluster.py
+++ b/tests/integration/meshnet/test_linked_cluster.py
@@ -106,6 +106,10 @@ class TestLinkedConcurrentCluster(TestLinkedCluster):
             raise SkipTest
 
     def spawn_docker_instances(self):
+        # Must create shared secret beforehand otherwise the
+        # testcase does not know which instances are relevant
+        ensure_shared_secret('cjdns')
+
         spawn_command = "spawn --no-assimilate " \
                         "--server-type headless " \
                         "--compute-type docker"

--- a/tests/integration/meshnet/test_simple_cluster.py
+++ b/tests/integration/meshnet/test_simple_cluster.py
@@ -2,6 +2,7 @@ from multiprocessing.pool import ThreadPool
 from os import environ
 from unittest import SkipTest
 
+from raptiformica.settings.meshnet import ensure_shared_secret
 from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
 
@@ -68,6 +69,10 @@ class TestSimpleConcurrentCluster(TestSimpleCluster):
             raise SkipTest
 
     def spawn_docker_instances(self):
+        # Must create shared secret beforehand otherwise the
+        # testcase does not know which instances are relevant
+        ensure_shared_secret('cjdns')
+
         spawn_command = "spawn --server-type headless --compute-type docker"
         pool = ThreadPool(self.workers)
         for _ in range(self.amount_of_instances):

--- a/tests/integration/meshnet/test_tree_cluster.py
+++ b/tests/integration/meshnet/test_tree_cluster.py
@@ -2,6 +2,7 @@ from multiprocessing.pool import ThreadPool
 from os import environ
 from unittest import SkipTest
 
+from raptiformica.settings.meshnet import ensure_shared_secret
 from tests.testcase import IntegrationTestCase, run_raptiformica_command
 
 
@@ -92,6 +93,10 @@ class TestTreeConcurrentCluster(TestTreeCluster):
             raise SkipTest
 
     def spawn_docker_instances(self):
+        # Must create shared secret beforehand otherwise the
+        # testcase does not know which instances are relevant
+        ensure_shared_secret('cjdns')
+
         spawn_command = "spawn --no-assimilate " \
                         "--server-type headless " \
                         "--compute-type docker"

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -136,7 +136,7 @@ class IntegrationTestCase(TestCase):
 
     def list_docker_instances(self):
         list_docker_instances_command = "sudo docker ps | " \
-                                        "grep raptiformica | " \
+                                        "grep my_init | " \
                                         "awk '{print$1}'"
         _, standard_out, standard_error = run_command_print_ready(
             list_docker_instances_command,
@@ -146,7 +146,7 @@ class IntegrationTestCase(TestCase):
 
     def docker_instance_is_relevant(self, instance_id):
         """
-        Check if a docker instance is relevant oo this
+        Check if a docker instance is relevant to this
         testcase
         :param str instance_id: The docker ID to check
         :return bool relevant: True if relevant, False if not


### PR DESCRIPTION
create the shared secret before spawning the concurrent test instances.
if this is not done beforehand the testcase will not know what instances
are relevant to the testcase