### PR TITLE
catch socket timeout in data store test

### DIFF
--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -1,3 +1,4 @@
+import socket
 import unittest
 from functools import partial
 from os.path import expanduser
@@ -198,7 +199,7 @@ class IntegrationTestCase(TestCase):
                 )
             )
 
-    @retry(attempts=30, expect=(AssertionError, URLError))
+    @retry(attempts=30, expect=(AssertionError, URLError, socket.timeout, socket.error))
     def check_data_can_be_stored_in_the_distributed_kv_store(self):
         sleep(2)
         expected_value = str(uuid4())


### PR DESCRIPTION
```
  File "/var/lib/jenkins/workspace/raptiformica/tests/integration/meshnet/test_simple_cluster.py", line 49, in verify_cluster_is_operational
    self.check_data_can_be_stored_in_the_distributed_kv_store()
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/utils.py", line 149, in retry_wrapper
    return func(*args, **kwargs)
  File "/var/lib/jenkins/workspace/raptiformica/tests/testcase.py", line 209, in check_data_can_be_stored_in_the_distributed_kv_store
    upload_config_mapping({'test/some/key/in/some/path': expected_value})
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 173, in upload_config_mapping
    try_config_request(lambda: consul_conn.put_mapping(batch))
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 138, in try_config_request
    return func()
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/settings/load.py", line 173, in <lambda>
    try_config_request(lambda: consul_conn.put_mapping(batch))
  File "/var/lib/jenkins/workspace/raptiformica/consul_kv/__init__.py", line 41, in put_mapping
    timeout=self.timeout
  File "/var/lib/jenkins/workspace/raptiformica/consul_kv/api.py", line 91, in put_kv_txn
    with request.urlopen(req, timeout=timeout) as f:
  File "/usr/lib64/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/lib64/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 1346, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib64/python3.6/urllib/request.py", line 1321, in do_open
    r = h.getresponse()
  File "/usr/lib64/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib64/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out
```