### PR TITLE
wait longer for consul consensus in testcase

### DIFF
--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -94,9 +94,9 @@ class IntegrationTestCase(TestCase):
         self.clean_up_cache_dir()
         print("Cleaned up any lingering state\n\n")
 
-    @retry(attempts=60, expect=(AssertionError,))
+    @retry(attempts=30, expect=(AssertionError,))
     def check_consul_consensus_was_established(self, expected_peers=None):
-        sleep(1)
+        sleep(5)
         consul_members_output = run_raptiformica_command(
             self.temp_cache_dir, "members", buffered=True
         )


### PR DESCRIPTION
this happens once in a while when running the integration tests, I'm guessing that the raptiformica agent would force a rejoin if the test just waited a bit longer. the agent runs every 30 seconds but it blocks on consul joins which might take a while if the overlay network hasn't been established yet making the current 60 seconds wait not enough in some cases.
```
FAIL: test_tree_cluster_establishes_mesh_correctly (tests.integration.meshnet.test_tree_cluster.TestTreeCluster)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/raptiformica/tests/integration/meshnet/test_tree_cluster.py", line 81, in test_tree_cluster_establishes_mesh_correctly
    self.check_consul_consensus_was_established(expected_peers=self.amount_of_instances)
  File "/var/lib/jenkins/workspace/raptiformica/raptiformica/utils.py", line 149, in retry_wrapper
    return func(*args, **kwargs)
  File "/var/lib/jenkins/workspace/raptiformica/tests/testcase.py", line 117, in check_consul_consensus_was_established
    consul_members_output)
AssertionError: 2 != 3 : Did not find enough (2 of the 3) alive agents. consul members output: Node                                     Address                                         Status  Type    Build  Protocol  DC
fc18:080a:c9b2:cd57:f837:1ce3:1ef3:c0e3  [fc18:80a:c9b2:cd57:f837:1ce3:1ef3:c0e3]:8301   alive   server  0.9.2  2         raptiformica
fcb1:9b59:eb1e:7e5f:5189:7e9e:a2fc:7ec2  [fcb1:9b59:eb1e:7e5f:5189:7e9e:a2fc:7ec2]:8301  alive   server  0.9.2  2         raptiformica
fcd9:ce0b:f9dd:25c1:7fdc:d0bc:d606:4deb  [fcd9:ce0b:f9dd:25c1:7fdc:d0bc:d606:4deb]:8301  left    server  0.9.2  2         raptiformica

```