### PR TITLE
update check if running in docker test

### DIFF
--- a/raptiformica/actions/agent.py
+++ b/raptiformica/actions/agent.py
@@ -40,7 +40,7 @@ def agent_already_running():
                     "grep -v screen -i | grep python3 | grep -v 'sh -c' | " \
                     "awk '{{print $2}}' | xargs --no-run-if-empty -I {{}} " \
                     "sh -c \"grep -q docker /proc/{{}}/cgroup 2> /dev/null " \
-                    "&& grep -qv docker /proc/1/cgroup || echo {{}}\" | " \
+                    "&& ! grep -q name=systemd:/docker /proc/1/cgroup || echo {{}}\" | " \
                     "wc -l | {{ read li; test $li -gt {}; }}" \
                     "".format(allowed_procs)
     return check_nonzero_exit(check_running)

--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -287,7 +287,7 @@ def stop_detached_cjdroute():
     kill_running = "ps aux | grep [c]jdroute | awk '{print $2}' | " \
                    "xargs --no-run-if-empty -I {} " \
                    "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                   "grep -qv docker /proc/1/cgroup || kill {}\""
+                   "! grep -q name=systemd:/docker /proc/1/cgroup || kill {}\""
     run_command_print_ready(
         kill_running,
         shell=True,
@@ -305,7 +305,6 @@ def check_if_port_available_factory(port):
     def check_if_port_available():
         """
         Check if a port is in use
-        :param int port: The port to check
         :return bool not_in_use: True if not in use, False if in use
         """
         check_port_command = "netstat -tuna | grep {:d}".format(port)
@@ -523,7 +522,7 @@ def ensure_no_consul_running():
     kill_running = "ps aux | grep [c]onsul | awk '{print $2}' | " \
                    "xargs --no-run-if-empty -I {} " \
                    "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                   "grep -qv docker /proc/1/cgroup || kill -2 {}\""  # SIGINT
+                   "! grep -q name=systemd:/docker /proc/1/cgroup || kill -2 {}\""  # SIGINT
     run_command_print_ready(
         kill_running,
         shell=True,

--- a/tests/unit/raptiformica/actions/agent/test_agent_already_running.py
+++ b/tests/unit/raptiformica/actions/agent/test_agent_already_running.py
@@ -20,7 +20,7 @@ class TestAgentAlreadyRunning(TestCase):
                            "grep -v screen -i | grep python3 | grep -v 'sh -c' | " \
                            "awk '{print $2}' | xargs --no-run-if-empty -I {} " \
                            "sh -c \"grep -q docker /proc/{}/cgroup 2> /dev/null " \
-                           "&& grep -qv docker /proc/1/cgroup || echo {}\" | " \
+                           "&& ! grep -q name=systemd:/docker /proc/1/cgroup || echo {}\" | " \
                            "wc -l | { read li; test $li -gt 0; }"
         self.check_nonzero_exit.assert_called_once_with(
             expected_command
@@ -35,7 +35,7 @@ class TestAgentAlreadyRunning(TestCase):
                            "grep -v screen -i | grep python3 | grep -v 'sh -c' | " \
                            "awk '{print $2}' | xargs --no-run-if-empty -I {} " \
                            "sh -c \"grep -q docker /proc/{}/cgroup 2> /dev/null " \
-                           "&& grep -qv docker /proc/1/cgroup || echo {}\" | " \
+                           "&& ! grep -q name=systemd:/docker /proc/1/cgroup || echo {}\" | " \
                            "wc -l | { read li; test $li -gt 1; }"
         self.check_nonzero_exit.assert_called_once_with(
             expected_command

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_no_consul_running.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_no_consul_running.py
@@ -22,7 +22,7 @@ class TestEnsureNoConsulRunning(TestCase):
         expected_command = "ps aux | grep [c]onsul | awk '{print $2}' | " \
                            "xargs --no-run-if-empty -I {} " \
                            "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                           "grep -qv docker /proc/1/cgroup || kill -2 {}\""
+                           "! grep -q name=systemd:/docker /proc/1/cgroup || kill -2 {}\""
         self.run_command_print_ready.assert_called_once_with(
             expected_command,
             shell=True,
@@ -47,7 +47,7 @@ class TestEnsureNoConsulRunning(TestCase):
         )
         self.assertIn(
             "-I {} sh -c \"grep -q docker /proc/{}/cgroup && "
-            "grep -qv docker /proc/1/cgroup || kill -2 {}\"",
+            "! grep -q name=systemd:/docker /proc/1/cgroup || kill -2 {}\"",
             expected_command,
             'Should only kill processes not in Docker containers unless '
             'running inside a Docker, those could have their own raptiformica '

--- a/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
+++ b/tests/unit/raptiformica/actions/mesh/test_stop_detached_cjdroute.py
@@ -23,7 +23,7 @@ class TestStopDetachedCjdroute(TestCase):
         expected_command = "ps aux | grep [c]jdroute | awk '{print $2}' | " \
                            "xargs --no-run-if-empty -I {} " \
                            "sh -c \"grep -q docker /proc/{}/cgroup && " \
-                           "grep -qv docker /proc/1/cgroup || kill {}\""
+                           "! grep -q name=systemd:/docker /proc/1/cgroup || kill {}\""
         self.execute_process.assert_called_once_with(
             expected_command,
             shell=True,
@@ -49,7 +49,7 @@ class TestStopDetachedCjdroute(TestCase):
         )
         self.assertIn(
             "-I {} sh -c \"grep -q docker /proc/{}/cgroup && "
-            "grep -qv docker /proc/1/cgroup || kill {}\"",
+            "! grep -q name=systemd:/docker /proc/1/cgroup || kill {}\"",
             expected_command,
             'Should only kill processes not in Docker containers unless '
             'running inside a Docker, those could have their own raptiformica '


### PR DESCRIPTION
`grep -qv docker /proc/1/cgroup` is not specific enough, will fail and cause infinite processes to be spawned if lines that do not contain 'docker' are in the `/proc/1/cgroup` file

```
root@98b476fc486a:~# cat /proc/1/cgroup
11:memory:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
10:blkio:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
9:cpuset:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
8:devices:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
7:perf_event:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
6:rdma:/
5:pids:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
4:freezer:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
3:net_cls,net_prio:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
2:cpu,cpuacct:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
1:name=systemd:/docker/98b476fc486aa7bac605b96724646ce0f192db5d2d8e38be1a8d7bd5f2c95eff
0::/system.slice/docker.service

root@98b476fc486a:~# grep -v docker /proc/1/cgroup
6:rdma:/
```