### PR TITLE
remote file upload is retried

### DIFF
--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -77,7 +77,7 @@ def upload(source, destination, host, port=22, timeout=1800):
     return exit_code
 
 
-@retry(attempts=3, expect=(TimeoutError,))
+@retry(attempts=3, expect=(TimeoutError, RuntimeError))
 def upload_self(host, port=22):
     """
     Upload the source code of the current raptiformica checkout to the remote host.

--- a/tests/integration/meshnet/test_simple_cluster.py
+++ b/tests/integration/meshnet/test_simple_cluster.py
@@ -88,7 +88,7 @@ class TestSimpleConcurrentCluster(TestSimpleCluster):
 
 class TestSimpleSemiConcurrentCluster(TestSimpleConcurrentCluster):
     """
-    Same as the SimpleCluster case but all two of the three instances boot
+    Same as the SimpleCluster case but two of the three instances boot
     at the same time instead of one after the other.
     """
     workers = 2


### PR DESCRIPTION
when running `raptiformica spawn` concurrently sometimes this can happen:
```
RuntimeError: Something went wrong uploading files to the remote host
Warning: Permanently added '172.17.0.4' (ECDSA) to the list of known hosts.
file has vanished: "/root/.raptiformica.d/artifacts/repositories/cjdns/.git/objects/pack/tmp_pack_QjxYaF"
rsync warning: some files vanished before they could be transferred (code 24) at main.c(1178) [sender=3.1.2]
```