### PR TITLE
increase integration test spawn timeout

### DIFF
--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -33,7 +33,8 @@ def run_raptiformica_command(cache_dir, parameters, buffered=False):
                                      parameters, cache_dir)
     _, standard_out, standard_error = run_command_print_ready(
         raptiformica_command,
-        buffered=buffered, shell=True
+        buffered=buffered, shell=True,
+        timeout=1800
     )
     return standard_out
 


### PR DESCRIPTION
so tests can be run on slower machines:
```
File "/srv/jenkins/workspace/raptiformica/tests/integration/meshnet/test_linked_cluster.py", line 47, in setUp
    self.spawn_docker_instances()
  File "/srv/jenkins/workspace/raptiformica/tests/integration/meshnet/test_linked_cluster.py", line 36, in spawn_docker_instances
    run_raptiformica_command(self.temp_cache_dir, spawn_command)
  File "/srv/jenkins/workspace/raptiformica/tests/testcase.py", line 36, in run_raptiformica_command
    buffered=buffered, shell=True
  File "/srv/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 345, in run_command_print_ready
    buffered=buffered, shell=shell, timeout=timeout
  File "/srv/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 265, in run_command
    timeout=timeout
  File "/srv/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 180, in run_command_locally
    command, buffered=buffered, shell=shell, timeout=timeout
  File "/srv/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 146, in execute_process
    write_real_time_output(process)
  File "/srv/jenkins/workspace/raptiformica/raptiformica/shell/execute.py", line 78, in write_real_time_output
    for line in iter(process.stdout.readline, b''):
  File "/root/.virtualenvs/raptiformica/lib/python3.6/site-packages/nose/plugins/multiprocess.py", line 276, in signalhandler
    raise TimedOutException()
nose.plugins.multiprocess.TimedOutException: 'test_linked_cluster_establishes_mesh_correctly (tests.integration.meshnet.test_linked_cluster.TestLinkedCluster)'
```