### PR TITLE
check more times for shared secret change in test

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -635,7 +635,7 @@ def consul_shared_secret_changed():
     )
 
 
-@retry(attempts=5, expect=(ConsulSharedSecretChanged,))
+@retry(attempts=30, expect=(ConsulSharedSecretChanged,))
 def raise_if_shared_secret_changed():
     """
     Raise exception if the consul shared secret changed.

--- a/tests/unit/raptiformica/actions/mesh/test_raise_if_shared_secret_changed.py
+++ b/tests/unit/raptiformica/actions/mesh/test_raise_if_shared_secret_changed.py
@@ -30,7 +30,7 @@ class TestRaiseIfSharedSecretChanged(TestCase):
         with suppress(ConsulSharedSecretChanged):
             raise_if_shared_secret_changed()
 
-        self.assertEqual(self.sleep.call_count, 5)
+        self.assertEqual(self.sleep.call_count, 30)
 
     def test_raise_if_shared_secret_changed_raises_exception_if_changed(self):
         self.consul_shared_secret_changed.return_value = True


### PR DESCRIPTION
in case the agent can still fix it. by checking more the
integration tests have a bigger change of still passing if this
situation occurs on slower machines.

```
RuntimeError: Failed to run raptiformica command on remote host
Warning: Permanently added '172.17.0.4' (ECDSA) to the list of known hosts.
Traceback (most recent call last):
  File "/usr/etc/raptiformica/raptiformica/actions/mesh.py", line 690, in restart_consul_agent_if_necessary
    raise_if_shared_secret_changed()
  File "/usr/etc/raptiformica/raptiformica/utils.py", line 149, in retry_wrapper
    return func(*args, **kwargs)
  File "/usr/etc/raptiformica/raptiformica/actions/mesh.py", line 650, in raise_if_shared_secret_changed
    "The consul shared might have become stale"
raptiformica.actions.mesh.ConsulSharedSecretChanged: The consul shared might have become stale
```