### PR TITLE
fix cjdroute build on raspberry pi

### DIFF
--- a/resources/setup_cjdns.sh
+++ b/resources/setup_cjdns.sh
@@ -12,6 +12,7 @@ if [ ! -f cjdroute ]; then
         cp ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/cjdroute .
     else
         echo 'compiling new cjdoute'
+        lsb_release -a 2>&1 | grep Raspbian -i -q && sed -i 's/-march=native/-mcpu=cortex-a53/g' node_build/make.js || /bin/true
         lsb_release -a 2>&1 | grep Raspbian -i -q && Seccomp_NO=1 ./do || ./do
         mkdir -p ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/
         cp -f cjdroute ~/.raptiformica.d/artifacts/$(uname -m)/cjdns/


### PR DESCRIPTION
fixes:
```
#/usr/etc/cjdns# ./do
Initialize 148ms
{"isLLVM":false,"isClang":false,"isGCC":true,"version":"4.9.2"}
Build NaCl
Creating directories
*** Error in `gcc': double free or corruption (top): 0x0032d208 ***
Compiler supports link time optimization
*** Error in `gcc': double free or corruption (top): 0x016f8d10 ***
Getting system type
*** Error in `gcc': double free or corruption (top): 0x000d9d28 ***
Total build time: 684ms.
/usr/etc/cjdns/build_linux/dependencies/cnacl/node_build/AbiName.js:4
    if (!retcode) { throw new Error("expected error from abiname_xcompile.c!"); }
```