### PR TITLE
install puppet and modules in base boxes

### DIFF
--- a/modules/compute/docker/Dockerfile
+++ b/modules/compute/docker/Dockerfile
@@ -16,5 +16,9 @@ RUN apt-get update && apt-get install -y \
     wget \
     unzip \
     screen \
-    git
+    git \
+    puppet
+RUN puppet module install puppetlabs-vcsrepo
+RUN puppet module install maestrodev-wget
+RUN puppet module install saz-sudo
 

--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -4,7 +4,11 @@ echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer
 
 pacman -Sy archlinux-keyring --noconfirm --needed
 pacman -Sy --noconfirm
-pacman -S ruby git acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
+
+pacman -S ruby git puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
+puppet module install puppetlabs-vcsrepo
+puppet module install maestrodev-wget
+puppet module install saz-sudo
 
 # Make sure the kernel is not upgraded on 'pacman -Syu' because otherwise we'd need to reboot
 # yet again before docker will work inside the virtualized guest due to the right veth kernel module 


### PR DESCRIPTION
should eventually be removed to make the base box more light-weight but
without this all server types would have to overwrite the compute type
with something that installs these additional dependencies as well which
is more confusing.