### PR TITLE
do not reload cjdroute every 30 seconds

### DIFF
--- a/raptiformica/actions/mesh.py
+++ b/raptiformica/actions/mesh.py
@@ -145,7 +145,6 @@ def configure_consul_conf():
     """
     Configure the consul config according to the
     information in the inherited mutable config.
-    :param dict config: the mutable config
     :return:
     """
     log.info("Configuring consul config")

--- a/raptiformica/utils.py
+++ b/raptiformica/utils.py
@@ -204,7 +204,10 @@ def calculate_lines_checksum(filename):
     with open(filename, 'rb') as f:
         lines = f.readlines()
         sorted_lines = sorted(lines)
-        file_hash.update(b'\n'.join(sorted_lines))
+        sorted_lines_stripped_trailing_comma = [
+            sl.rstrip(b',') for sl in sorted_lines
+        ]
+        file_hash.update(b'\n'.join(sorted_lines_stripped_trailing_comma))
         return file_hash.hexdigest()
 
 


### PR DESCRIPTION
there was a bug where the CJDROUTE_CONF_HASH was calculated as changed
every time the nodeterministic unsorted json was written to disk in a
slightly different order than before. The trailing commas would end up
on different lines, causing the checksum to change every time. This
prevented the network to stabilize after a certain amount of nodes was
reached.

Before diff in cjdroute.conf
```
diff beforesorted.txt aftersorted.txt
36c36
<             "allowedConnections": [],
---
>             "allowedConnections": []
38c38
<                 "beacon": 0,
---
>                 "beacon": 0
44c44
<                 "connectTo": {}
---
>                 "connectTo": {},
50,51c50,51
<             "keepNetAdmin": 1
<     "logging": {},
---
>             "keepNetAdmin": 1,
>     "logging": {}
55,57c55,57
<             "outgoingConnections": []
<                         "password": "bla"
<                         "password": "bla"
---
>             "outgoingConnections": [],
>                         "password": "bla",
>                         "password": "bla",
60,62c60,62
<                         "peerName": "192.168.1.123:5219",
<                         "peerName": "192.168.1.124:5219",
<     "privateKey": "bla"
---
>                         "peerName": "192.168.1.123:5219"
>                         "peerName": "192.168.1.124:5219"
>     "privateKey": "bla",
70c70
<             "setuser": "nobody",
---
>             "setuser": "nobody"
```

After diff:
```
diff aftersortednocomma.txt beforesortednocomma.txt
...
```

For future reference, debugged with:
```
$ /usr/etc/cjdns/contrib/python
./cexec 'RouterModule_pingNode("<some ipv6 address>")'
```

Shows this when ping is OK
```
{'deprecation': 'from,protocol,version will soon be removed', 'protocol': 20, 'addr': 'bla', 'txid': 'bla', 'version': 'unknown', 'result': 'pong', 'ms': 136, 'from': 'bla'}
```

This when peer can not be found
```
{'txid': 'DC758OA9TY', 'error': 'not_found'}
```

This on timeout
```
{'deprecation': 'from,protocol,version will soon be removed', 'version': 'unknown', 'result': 'timeout', 'ms': 3000, 'txid': 'bla'}
``