### PR TITLE
fix checksum discrepancy

### DIFF
--- a/raptiformica/utils.py
+++ b/raptiformica/utils.py
@@ -203,12 +203,12 @@ def calculate_lines_checksum(filename):
     file_hash = hashlib.sha1()
     with open(filename, 'rb') as f:
         lines = f.readlines()
-        sorted_lines = sorted(lines)
-        sorted_lines_stripped_trailing_comma = [
-            sl.encode('utf-8').rstrip(b',') if hasattr(sl, 'encode')
-            else sl.rstrip(b',') for sl in sorted_lines
+        stripped_trailing_comma_lines = [
+            sl.encode('utf-8').rstrip(b',\n') if hasattr(sl, 'encode')
+            else sl.rstrip(b',\n') for sl in lines
         ]
-        file_hash.update(b'\n'.join(sorted_lines_stripped_trailing_comma))
+        sorted_lines = sorted(stripped_trailing_comma_lines)
+        file_hash.update(b'\n'.join(sorted_lines))
         return file_hash.hexdigest()
 
 


### PR DESCRIPTION
expected
```
vdloo@asuran:~/files/thediff$ cat before.txt | sed 's/,*$//g' | sort | md5sum
1ea5b4f2365c524a86b695b44484464c  -
vdloo@asuran:~/files/thediff$ cat after.txt | sed 's/,*$//g' | sort | md5sum
1ea5b4f2365c524a86b695b44484464c  -
```

before
```
In [2]: from raptiformica.actions.mesh import *

In [3]: calculate_lines_checksum('/home/vdloo/files/thediff/before.txt')
Out[3]: '683c0dc0a56d6e4770f6dfbfdfc3370f6e0f0383'

In [4]: calculate_lines_checksum('/home/vdloo/files/thediff/after.txt')
Out[4]: '83b72f4bebac2c929ecc23996c4182125ee89501'
```

after
```
In [2]: calculate_lines_checksum('/home/vdloo/files/thediff/before.txt')
Out[2]: 'a4e3eb9b78121f87b7659c5a9b1601601a0a1a4f'

In [3]: calculate_lines_checksum('/home/vdloo/files/thediff/after.txt')
Out[3]: 'a4e3eb9b78121f87b7659c5a9b1601601a0a1a4f'
```