### PR TITLE
reomve local consul state dir if outage detected

### DIFF
--- a/tests/unit/raptiformica/actions/mesh/test_consul_outage_detected.py
+++ b/tests/unit/raptiformica/actions/mesh/test_consul_outage_detected.py
@@ -1,0 +1,36 @@
+from raptiformica.actions.mesh import consul_outage_detected, WAIT_FOR_CONSUL_TIMEOUT
+from tests.testcase import TestCase
+
+
+class TestConsulOutageDetected(TestCase):
+    def setUp(self):
+        self.run_command = self.set_up_patch(
+            'raptiformica.actions.mesh.run_command'
+        )
+        self.run_command.return_value = (0, 'output', '')
+
+    def test_consul_outage_detected_runs_kv_get_for_api_version(self):
+        consul_outage_detected()
+
+        expected_command = ['consul', 'kv', 'get', '/raptiformica/raptiformica_api_version']
+
+        self.run_command.assert_called_once_with(expected_command, timeout=WAIT_FOR_CONSUL_TIMEOUT)
+
+    def test_consul_outage_detected_returns_false_if_no_outage_detected(self):
+        ret = consul_outage_detected()
+
+        self.assertFalse(ret)
+
+    def test_consul_outage_detected_returns_false_if_no_stderr_retrieved(self):
+        self.run_command.return_value = (1, 'output', None)
+
+        ret = consul_outage_detected()
+
+        self.assertFalse(ret)
+
+    def test_consul_outage_detected_returns_true_if_got_500_from_consul_agent(self):
+        self.run_command.return_value = (1, '', 'Error querying Consul agent: Unexpected response code: 500\n')
+
+        ret = consul_outage_detected()
+
+        self.assertTrue(ret)

--- a/tests/unit/raptiformica/actions/mesh/test_ensure_consul_agent.py
+++ b/tests/unit/raptiformica/actions/mesh/test_ensure_consul_agent.py
@@ -7,6 +7,9 @@ from tests.testcase import TestCase
 class TestEnsureConsulAgent(TestCase):
     def setUp(self):
         self.log = self.set_up_patch('raptiformica.actions.mesh.log')
+        self.flush_consul_agent_if_necessary = self.set_up_patch(
+            'raptiformica.actions.mesh.flush_consul_agent_if_necessary'
+        )
         self.check_if_consul_is_available = self.set_up_patch(
             'raptiformica.actions.mesh.check_if_consul_is_available'
         )
@@ -27,6 +30,11 @@ class TestEnsureConsulAgent(TestCase):
         ensure_consul_agent()
 
         self.log.info.assert_called_once_with(ANY)
+
+    def test_ensure_consul_agent_flushes_consul_agent_if_necessary(self):
+        ensure_consul_agent()
+
+        self.flush_consul_agent_if_necessary.assert_called_once_with()
 
     def test_ensure_consul_agent_checks_if_consul_is_available(self):
         ensure_consul_agent()

--- a/tests/unit/raptiformica/actions/mesh/test_flush_consul_agent_if_necessary.py
+++ b/tests/unit/raptiformica/actions/mesh/test_flush_consul_agent_if_necessary.py
@@ -1,0 +1,30 @@
+from raptiformica.actions.mesh import flush_consul_agent_if_necessary
+from tests.testcase import TestCase
+
+
+class TestFlushConsulAgentIfNecessary(TestCase):
+    def setUp(self):
+        self.consul_outage_detected = self.set_up_patch(
+            'raptiformica.actions.mesh.consul_outage_detected'
+        )
+        self.consul_outage_detected.return_value = False
+        self.remove_consul_local_state = self.set_up_patch(
+            'raptiformica.actions.mesh.remove_consul_local_state'
+        )
+
+    def test_flush_consul_agent_if_necessary_checks_if_consul_outage_detected(self):
+        flush_consul_agent_if_necessary()
+
+        self.consul_outage_detected.assert_called_once_with()
+
+    def test_flush_consul_agent_if_necessary_removes_consul_local_state_if_detected(self):
+        self.consul_outage_detected.return_value = True
+
+        flush_consul_agent_if_necessary()
+
+        self.remove_consul_local_state.assert_called_once_with()
+
+    def test_flush_consul_agent_if_necessary_does_not_remove_consul_local_state_if_not_detected(self):
+        flush_consul_agent_if_necessary()
+
+        self.assertFalse(self.remove_consul_local_state.called)

--- a/tests/unit/raptiformica/actions/mesh/test_remove_consul_local_state.py
+++ b/tests/unit/raptiformica/actions/mesh/test_remove_consul_local_state.py
@@ -1,0 +1,18 @@
+from functools import partial
+from unittest.mock import call
+from tests.testcase import TestCase
+
+from raptiformica.actions.mesh import remove_consul_local_state, CONSUL_STATE_DIRS
+
+
+class TestRemoveConsulLocalState(TestCase):
+    def setUp(self):
+        self.rmtree = self.set_up_patch(
+            'raptiformica.actions.mesh.rmtree'
+        )
+
+    def test_remove_consul_local_state_removes_tree_of_all_state_dirs(self):
+        remove_consul_local_state()
+
+        expected_calls = map(partial(call, ignore_errors=True), CONSUL_STATE_DIRS)
+        self.assertCountEqual(expected_calls, self.rmtree.mock_calls)


### PR DESCRIPTION
Remove all local consul state. If there was a consul outage some data might
now be lost. That should be OK because the consensus is best effort and any
state stored in the distributed key value store should be commutative and
persisted on disk periodically. Once a new quorum has been established the
state from disk will be pushed to the kv store once again. Any other nodes
with other local data will push (over) the same store until an equilibrium
has been reached.