### PR TITLE
do not uplaod last advertised

### DIFF
--- a/raptiformica/shell/rsync.py
+++ b/raptiformica/shell/rsync.py
@@ -57,7 +57,7 @@ def upload(source, destination, host, port=22, timeout=1800):
         '/usr/bin/env', 'rsync', '-q', '--force', '-avz',
         source, 'root@{}:{}'.format(host, destination),
         '--exclude=.venv', '--exclude=*.pyc',
-        '--exclude=var',
+        '--exclude=var', '--exclude=last_advertised',
         '-e', 'ssh -p {} '
               '-oStrictHostKeyChecking=no '
               '-oUserKnownHostsFile=/dev/null'.format(port)

--- a/tests/unit/raptiformica/shell/rsync/test_upload.py
+++ b/tests/unit/raptiformica/shell/rsync/test_upload.py
@@ -17,7 +17,8 @@ class TestUpload(TestCase):
         expected_upload_command = [
             '/usr/bin/env', 'rsync', '-q', '--force', '-avz',
             conf().PROJECT_DIR, 'root@1.2.3.4:{}'.format(conf().INSTALL_DIR),
-            '--exclude=.venv', '--exclude=*.pyc', '--exclude=var', '-e',
+            '--exclude=.venv', '--exclude=*.pyc', '--exclude=var',
+            '--exclude=last_advertised', '-e',
             'ssh -p 22 -oStrictHostKeyChecking=no '
             '-oUserKnownHostsFile=/dev/null'
         ]


### PR DESCRIPTION
otherwise the last advertised set [here](https://github.com/vdloo/raptiformica/blob/master/raptiformica/actions/slave.py#L88) will be overwritten with the advertised address of the machine performing the assimilation [here](https://github.com/vdloo/raptiformica/blob/master/raptiformica/actions/slave.py#L102)

which results in the address of the point of origin being slowly propagated throughout all machines in the cluster
```
cat .raptiformica.d/mutable_config.json | grep 199
    "raptiformica/meshnet/neighbours/8298s607r7kuxfzj3nbvktrckn518nmjk7n10lc8klv43pzw8040.k/host": "192.168.1.199",
    "raptiformica/meshnet/neighbours/8rrwct2n3yqlfhy1msul8290zckpdfft7j7s8l9j484q43s3lq80.k/host": "192.168.1.199",
    "raptiformica/meshnet/neighbours/yg2x0kwfnprg9dxth6ghdwx7u1yutlrcmmmbyugklr40ut0k1940.k/host": "192.168.1.199",
```