### PR TITLE
ran out of attempts is debug not warning

### DIFF
--- a/raptiformica/utils.py
+++ b/raptiformica/utils.py
@@ -150,7 +150,7 @@ def retry(attempts=2, expect=(RuntimeError,), wait_before_retry=None):
                     return func(*args, **kwargs)
                 except expect:
                     if attempts_left <= 0:
-                        log.warning(
+                        log.debug(
                             "Ran out of attempts for this function! Not "
                             "catching expected exception anymore."
                         )


### PR DESCRIPTION
when there is no quorum yet all config lookups will fail (because there
is no shared config yet). in those cases no failure message should be
displayed (without context). for example:

```
raptiformica install vdloo/raptiformica-map
Ran out of attempts for this function! Not catching expected exception anymore.
Checking out vdloo/raptiformica-map
Cloning https://github.com/vdloo/raptiformica-map to /root/.raptiformica.d/modules/raptiformica-map
Ran out of attempts for this function! Not catching expected exception anymore
```