### PR TITLE
force ipv4 wgets

### DIFF
--- a/raptiformica/shell/wget.py
+++ b/raptiformica/shell/wget.py
@@ -17,6 +17,6 @@ def wget(url, host=None, port=22, failure_message='Failed retrieving file'):
     :return None:
     """
     run_critical_unbuffered_command_print_ready(
-        ['wget', '-nc', url], host=host, port=port,
+        ['wget', '-4', '-nc', url], host=host, port=port,
         failure_message=failure_message, timeout=WGET_TIMEOUT
     )

--- a/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
+++ b/tests/unit/raptiformica/shell/consul/test_ensure_latest_consul_release.py
@@ -44,7 +44,7 @@ class TestEnsureLatestConsulRelease(TestCase):
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4',
-            '-p', '2222', 'wget', '-nc',
+            '-p', '2222', 'wget', '-4', '-nc',
             'https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip'
         ]
         self.execute_process.assert_called_once_with(

--- a/tests/unit/raptiformica/shell/wget/test_wget.py
+++ b/tests/unit/raptiformica/shell/wget/test_wget.py
@@ -26,7 +26,7 @@ class TestWget(TestCase):
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'PasswordAuthentication=no',
             'root@1.2.3.4', '-p', '22',
-            'wget', '-nc', 'https://www.example.com/some_url.zip'
+            'wget', '-4', '-nc', 'https://www.example.com/some_url.zip'
         ]
         self.execute_process.assert_called_once_with(
             expected_command,


### PR DESCRIPTION
in case outbound ipv6 is not possible
```
[root@grid1 ~]# wget https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip
--2018-02-03 17:27:07--  https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving releases.hashicorp.com (releases.hashicorp.com)... 2a04:4e42:9::439, 151.101.37.183
Connecting to releases.hashicorp.com (releases.hashicorp.com)|2a04:4e42:9::439|:443...

^C

[root@grid1 ~]# wget https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip -4
--2018-02-03 17:28:00--  https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving releases.hashicorp.com (releases.hashicorp.com)... 151.101.37.183
Connecting to releases.hashicorp.com (releases.hashicorp.com)|151.101.37.183|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11098577 (11M) [application/zip]
Saving to: 'consul_1.0.2_linux_amd64.zip'

consul_1.0.2_linux_amd64.zip                                100%[==========================================================================================================================================>]  10.58M  33.0MB/s    in 0.3s

2018-02-03 17:28:00 (33.0 MB/s) - 'consul_1.0.2_linux_amd64.zip' saved [11098577/11098577]
```