### PR TITLE
install icu in default vagrant

### DIFF
--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -5,7 +5,7 @@ echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer
 pacman -Sy archlinux-keyring --noconfirm --needed
 pacman -Sy --noconfirm
 
-pacman -S ruby git puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
+pacman -S ruby git icu puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
 puppet module install puppetlabs-vcsrepo
 puppet module install maestrodev-wget
 puppet module install saz-sudo


### PR DESCRIPTION
fixes:
```
root@archlinux:~# puppet
libfacter was not found. Please make sure it was installed to the expected location.
libicudata.so.61: cannot open shared object file: No such file or directory - /usr/lib/libfacter.so

root@archlinux:~# facter
facter: error while loading shared libraries: libicudata.so.61: cannot open shared object file: No such file or directory

root@archlinux:~# pacman -S icu
resolving dependencies...
looking for conflicting packages...

Packages (1) icu-61.1-1

Total Download Size:    8.43 MiB
Total Installed Size:  35.10 MiB
Net Upgrade Size:       0.04 MiB

:: Proceed with installation? [Y/n] y
:: Retrieving packages...
 icu-61.1-1-x86_64                                      8.4 MiB  3.44M/s 00:02 [#############################################] 100%
(1/1) checking keys in keyring                                                 [#############################################] 100%
(1/1) checking package integrity                                               [#############################################] 100%
(1/1) loading package files                                                    [#############################################] 100%
(1/1) checking for file conflicts                                              [#############################################] 100%
(1/1) checking available disk space                                            [#############################################] 100%
:: Processing package changes...
(1/1) upgrading icu                                                            [#############################################] 100%
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
root@archlinux:~# puppet
See 'puppet help' for help on available puppet subcommands
```