### PR TITLE
install python3 in default vagrant

### DIFF
--- a/modules/compute/vagrant/deps/archlinux_deps.sh
+++ b/modules/compute/vagrant/deps/archlinux_deps.sh
@@ -5,7 +5,7 @@ echo -e 'Server = http://mirror.nl.leaseweb.net/archlinux/$repo/os/$arch\nServer
 pacman -Sy archlinux-keyring --noconfirm --needed
 pacman -Sy --noconfirm
 
-pacman -S ruby rsync git icu puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
+pacman -S ruby python3 rsync git icu puppet acl libmariadbclient nodejs base-devel iputils wget unzip screen --noconfirm --needed
 puppet module install puppetlabs-vcsrepo
 puppet module install maestrodev-wget
 puppet module install saz-sudo


### PR DESCRIPTION
this is not in the archlinux/archlinux vagrant image by default:
```
default_provisioner/modules/server/deploy.py
Running resource command: cd $HOME; export PYTHONPATH=/usr/etc/raptiformica_default_provisioner; /usr/etc/raptiformica_default_provisioner/modules/server/deploy.py
Traceback (most recent call last):
  File "/usr/share/raptiformica/bin/raptiformica_spawn.py", line 5, in <module>
    spawn()
  File "/usr/share/raptiformica/raptiformica/cli.py", line 165, in spawn
    only_check_available=args.check_available
  File "/usr/share/raptiformica/raptiformica/actions/spawn.py", line 130, in spawn_machine
    uuid=uuid
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 128, in slave_machine
    provision_machine(host, port=port, server_type=server_type)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 74, in provision_machine
    callback=bootstrap_provisioning
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 56, in ensure_source_on_machine
    callback(name, config)
  File "/usr/share/raptiformica/raptiformica/actions/slave.py", line 70, in bootstrap_provisioning
    run_resource_command(config['bootstrap'], name, host=host, port=port)
  File "/usr/share/raptiformica/raptiformica/utils.py", line 150, in retry_wrapper
    return func(*args, **kwargs)
  File "/usr/share/raptiformica/raptiformica/shell/config.py", line 38, in run_resource_command
    shell=True
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 345, in run_command_print_ready
    buffered=buffered, shell=shell, timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 257, in run_command
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 226, in run_command_remotely
    timeout=timeout
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 184, in run_command_locally
    failure_callback(process_output)
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 278, in print_ready_callback
    callback(make_process_output_print_ready(process_output))
  File "/usr/share/raptiformica/raptiformica/shell/execute.py", line 26, in raise_failure
    raise RuntimeError("{}\n{}".format(message, standard_error))
RuntimeError: Resource command exited nonzero, that might not be a problem. If something serious went wrong we'll try again next run.
Warning: Permanently added '172.28.128.3' (ECDSA) to the list of known hosts.
/usr/bin/env: 'python3': No such file or directory
```