### PR TITLE
deploy can install modules

### DIFF
--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -106,6 +106,10 @@ def parse_deploy_arguments():
                         choices=get_server_types(),
                         help='Specify a server type. Default is '
                              '{}'.format(get_first_server_type()))
+    parser.add_argument('--modules',
+                        help='Modules to install if any. '
+                             'For example vdloo/raptiformica-map',
+                        nargs='+', dest='modules', default=list())
     return parse_arguments(parser)
 
 
@@ -117,6 +121,8 @@ def deploy():
     :return None:
     """
     args = parse_deploy_arguments()
+    for module_name in args.modules:
+        load_module(module_name)
     deploy_network(
         args.inventory,
         server_type=args.server_type

--- a/tests/unit/raptiformica/cli/test_deploy.py
+++ b/tests/unit/raptiformica/cli/test_deploy.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from mock import Mock, call
 
 from raptiformica.cli import deploy
 from tests.testcase import TestCase
@@ -11,7 +11,14 @@ class TestDeploy(TestCase):
         )
         self.parse_deploy_arguments.return_value = Mock(
             inventory='~/.raptiformica_inventory',
-            server_type='headless'
+            server_type='headless',
+            modules=[
+                'vdloo/simulacra',
+                'vdloo/raptiformica-map'
+            ]
+        )
+        self.load_module = self.set_up_patch(
+            'raptiformica.cli.load_module'
         )
         self.deploy_network = self.set_up_patch(
             'raptiformica.cli.deploy_network'
@@ -21,6 +28,24 @@ class TestDeploy(TestCase):
         deploy()
 
         self.parse_deploy_arguments.assert_called_once_with()
+
+    def test_deploy_loads_modules_if_any(self):
+        deploy()
+
+        expected_calls = [
+            call('vdloo/simulacra'),
+            call('vdloo/raptiformica-map'),
+        ]
+        self.assertEqual(
+            expected_calls, self.load_module.mock_calls
+        )
+
+    def test_deploy_does_not_load_modules_if_none(self):
+        self.parse_deploy_arguments.return_value.modules = []
+
+        deploy()
+
+        self.assertFalse(self.load_module.called)
 
     def test_deploy_deploys_network(self):
         deploy()

--- a/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
@@ -32,9 +32,13 @@ class TestParseDeployArguments(TestCase):
 
         expected_calls = [
             call('inventory', type=str, help=ANY),
-            call('--server-type', type=str, default=self.get_first_server_type.return_value,
+            call('--server-type', type=str,
+                 default=self.get_first_server_type.return_value,
                  choices=self.get_server_types.return_value,
-                 help='Specify a server type. Default is {}'.format(self.get_first_server_type.return_value)),
+                 help='Specify a server type. Default is {}'
+                      ''.format(self.get_first_server_type.return_value)),
+            call('--modules', help=ANY, nargs='+',
+                 dest='modules', default=list()),
         ]
         self.assertEqual(
             self.argument_parser.return_value.add_argument.mock_calls,


### PR DESCRIPTION
note that this does not work if the machine running the deploy is also
the target and is running as root. that will wipe any installed modules
before running the the assimilation. depending on in what order the
machines are ordered in the inventory this could cause some unexpected
behavior.