### PR TITLE
deploy can run concurrently

### DIFF
--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -97,6 +97,7 @@ def parse_deploy_arguments():
         prog="raptiformica deploy",
         description='Set up or re-create an entire network based on a config file'
     )
+    concurrent = conf().DEPLOY_CONCURRENCY
     parser.add_argument('inventory', type=str,
                         help='Path to the inventory file. Contents like: '
                              '\'[{"dst": "1.2.3.4"}, {"dst": "2.3.4.5", "port": "2222"}, '
@@ -110,6 +111,10 @@ def parse_deploy_arguments():
                         help='Modules to install if any. '
                              'For example vdloo/raptiformica-map',
                         nargs='+', dest='modules', default=list())
+    parser.add_argument('--concurrent',
+                        help='How many machines to deploy to concurrently. '
+                             'Defaults to {}'.format(concurrent),
+                        type=int, default=concurrent)
     return parse_arguments(parser)
 
 

--- a/raptiformica/settings/__init__.py
+++ b/raptiformica/settings/__init__.py
@@ -28,6 +28,7 @@ class Config(object):
     CONSUL_DEFAULT_PORT = 8300
     MACHINE_ARCH = uname()[4]
     FORWARDED_CONSUL_ONCE_ALREADY = False
+    DEPLOY_CONCURRENCY = 5
 
     def set_cache_dir(self, cache_dir):
         """

--- a/tests/unit/raptiformica/actions/deploy/test_deploy_network.py
+++ b/tests/unit/raptiformica/actions/deploy/test_deploy_network.py
@@ -64,3 +64,17 @@ class TestDeployNetwork(TestCase):
             call('2.3.4.5', port=2222, server_type='workstation'),
         ]
         self.assertCountEqual(expected_calls, self.slave_machine.mock_calls)
+
+    def test_deploy_network_can_deploy_serially(self):
+        pool = self.set_up_patch('raptiformica.actions.deploy.ThreadPool')
+
+        deploy_network('~/.raptiformica_inventory', concurrent=1)
+
+        pool.assert_called_once_with(processes=1)
+
+    def test_deploy_network_deploys_concurrently_by_default(self):
+        pool = self.set_up_patch('raptiformica.actions.deploy.ThreadPool')
+
+        deploy_network('~/.raptiformica_inventory')
+
+        pool.assert_called_once_with(processes=5)

--- a/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
@@ -39,6 +39,8 @@ class TestParseDeployArguments(TestCase):
                       ''.format(self.get_first_server_type.return_value)),
             call('--modules', help=ANY, nargs='+',
                  dest='modules', default=list()),
+            call( '--concurrent', help=ANY,
+                  type=int, default=5)
         ]
         self.assertEqual(
             self.argument_parser.return_value.add_argument.mock_calls,


### PR DESCRIPTION
instead of deploying only one host at the same time. can still deploy serially by passing `--concurrent 1` if needed.