### PR TITLE
ensure artifacts directory

### DIFF
--- a/raptiformica/settings/load.py
+++ b/raptiformica/settings/load.py
@@ -60,7 +60,7 @@ def write_config_mapping(config, config_file):
     :param str config_file: The mutable config file
     :return None:
     """
-    ensure_directory(conf().ABS_CACHE_DIR)
+    ensure_directory(conf().USER_ARTIFACTS_DIR)
     # Lock the config cache file so two processes can't
     # write to the file at the same time and corrupt the json
     with config_cache_lock():

--- a/tests/unit/raptiformica/settings/load/test_write_config_mapping.py
+++ b/tests/unit/raptiformica/settings/load/test_write_config_mapping.py
@@ -1,9 +1,13 @@
+from raptiformica.settings import conf
 from raptiformica.settings.load import write_config_mapping
 from tests.testcase import TestCase
 
 
 class TestWriteConfigMapping(TestCase):
     def setUp(self):
+        self.ensure_directory = self.set_up_patch(
+            'raptiformica.settings.load.ensure_directory'
+        )
         self.write_json = self.set_up_patch(
             'raptiformica.settings.load.write_json'
         )
@@ -15,6 +19,19 @@ class TestWriteConfigMapping(TestCase):
         self.data = {
             'the': 'data'
         }
+
+    def test_write_config_ensures_artifact_directory(self):
+        write_config_mapping(self.data, 'a_config_file.json')
+
+        # Even though we only need the ABS_CACHE_DIR to
+        # exist here we still create the deeper level
+        # artifacts dir because that will be required
+        # later as well. TODO: find a better suited place
+        # to ensure the artifacts directory or make it not
+        # a hard requirement for download_artifacts
+        self.ensure_directory.assert_called_once_with(
+            conf().USER_ARTIFACTS_DIR
+        )
 
     def test_write_config_gets_config_cache_lock(self):
         write_config_mapping(self.data, 'a_config_file.json')


### PR DESCRIPTION
even if there are no newly generated artifacts on the remote server