### PR TITLE
raptiformica deploy can take optionals

### DIFF
--- a/raptiformica/cli.py
+++ b/raptiformica/cli.py
@@ -115,6 +115,14 @@ def parse_deploy_arguments():
                         help='How many machines to deploy to concurrently. '
                              'Defaults to {}'.format(concurrent),
                         type=int, default=concurrent)
+    parser.add_argument('--no-provision', action='store_true', default=False,
+                        help='Do not run the provisioning scripts for the specified server type')
+    parser.add_argument('--no-assimilate', action='store_true', default=False,
+                        help='Do not join or set up the distributed network.')
+    parser.add_argument('--no-after-assimilate', action='store_true', default=False,
+                        help='Do not perform the after assimilation hooks')
+    parser.add_argument('--no-after-mesh', action='store_true', default=False,
+                        help='Do not perform the after mesh hooks')
     return parse_arguments(parser)
 
 
@@ -131,7 +139,11 @@ def deploy():
     deploy_network(
         args.inventory,
         server_type=args.server_type,
-        concurrent=args.concurrent
+        concurrent=args.concurrent,
+        assimilate=not args.no_assimilate,
+        after_assimilate=not args.no_after_assimilate,
+        after_mesh=not args.no_after_mesh,
+        provision=not args.no_provision
     )
 
 

--- a/tests/unit/raptiformica/actions/deploy/test_deploy_network.py
+++ b/tests/unit/raptiformica/actions/deploy/test_deploy_network.py
@@ -51,8 +51,16 @@ class TestDeployNetwork(TestCase):
         deploy_network('~/.raptiformica_inventory')
 
         expected_calls = [
-            call('1.2.3.4', port=22, server_type=None),
-            call('2.3.4.5', port=2222, server_type=None),
+            call(
+                '1.2.3.4', port=22, server_type=None,
+                provision=False, assimilate=False,
+                after_assimilate=False, after_mesh=False
+            ),
+            call(
+                '2.3.4.5', port=2222, server_type=None,
+                provision=False, assimilate=False,
+                after_assimilate=False, after_mesh=False
+            ),
         ]
         self.assertCountEqual(expected_calls, self.slave_machine.mock_calls)
 
@@ -60,8 +68,16 @@ class TestDeployNetwork(TestCase):
         deploy_network('~/.raptiformica_inventory', server_type='workstation')
 
         expected_calls = [
-            call('1.2.3.4', port=22, server_type='workstation'),
-            call('2.3.4.5', port=2222, server_type='workstation'),
+            call(
+                '1.2.3.4', port=22, server_type='workstation',
+                provision=False, assimilate=False,
+                after_assimilate=False, after_mesh=False
+            ),
+            call(
+                '2.3.4.5', port=2222, server_type='workstation',
+                provision=False, assimilate=False,
+                after_assimilate=False, after_mesh=False
+            ),
         ]
         self.assertCountEqual(expected_calls, self.slave_machine.mock_calls)
 

--- a/tests/unit/raptiformica/cli/test_deploy.py
+++ b/tests/unit/raptiformica/cli/test_deploy.py
@@ -16,7 +16,11 @@ class TestDeploy(TestCase):
                 'vdloo/simulacra',
                 'vdloo/raptiformica-map'
             ],
-            concurrent=3
+            concurrent=3,
+            no_assimilate=False,
+            no_after_assimilate=False,
+            no_after_mesh=False,
+            no_provision=False
         )
         self.load_module = self.set_up_patch(
             'raptiformica.cli.load_module'
@@ -54,5 +58,9 @@ class TestDeploy(TestCase):
         self.deploy_network.assert_called_once_with(
             '~/.raptiformica_inventory',
             server_type='headless',
-            concurrent=3
+            concurrent=3,
+            assimilate=True,
+            after_assimilate=True,
+            after_mesh=True,
+            provision=True
         )

--- a/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
+++ b/tests/unit/raptiformica/cli/test_parse_deploy_arguments.py
@@ -32,15 +32,37 @@ class TestParseDeployArguments(TestCase):
 
         expected_calls = [
             call('inventory', type=str, help=ANY),
-            call('--server-type', type=str,
-                 default=self.get_first_server_type.return_value,
-                 choices=self.get_server_types.return_value,
-                 help='Specify a server type. Default is {}'
-                      ''.format(self.get_first_server_type.return_value)),
-            call('--modules', help=ANY, nargs='+',
-                 dest='modules', default=list()),
-            call( '--concurrent', help=ANY,
-                  type=int, default=5)
+            call(
+                '--server-type', type=str,
+                default=self.get_first_server_type.return_value,
+                choices=self.get_server_types.return_value,
+                help='Specify a server type. Default is {}'
+                     ''.format(self.get_first_server_type.return_value)
+            ),
+            call(
+                '--modules', help=ANY, nargs='+',
+                dest='modules', default=list()
+            ),
+            call(
+                '--concurrent', help=ANY,
+                type=int, default=5
+            ),
+            call(
+                '--no-provision', action='store_true',
+                default=False, help=ANY
+            ),
+            call(
+                '--no-assimilate', action='store_true',
+                default=False, help=ANY
+            ),
+            call(
+                '--no-after-assimilate', action='store_true',
+                default=False, help=ANY
+            ),
+            call(
+                '--no-after-mesh', action='store_true',
+                default=False, help=ANY
+            ),
         ]
         self.assertEqual(
             self.argument_parser.return_value.add_argument.mock_calls,


### PR DESCRIPTION
in case a node or nodes need to be updated with the deploy script but
any of the raptiformica assimilation stuff should not be executed.