### PR TITLE
do not crash if no delete key on cleanup

### DIFF
--- a/raptiformica/actions/prune.py
+++ b/raptiformica/actions/prune.py
@@ -172,13 +172,21 @@ def _get_neighbour_by_key(key, value):
     :return list [str, ..[: : List of keys in the neighbours with the value
     for the specified key
     """
-    config = get_config()
-    meshnet_config = config[conf().KEY_VALUE_PATH].get('meshnet', {})
-    neighbours = meshnet_config.get('neighbours', {})
-    return [
-        '{}/meshnet/neighbours/{}/'.format(conf().KEY_VALUE_PATH, k)
-        for k, v in neighbours.items() if v[key] == value
-    ]
+    try:
+        config = get_config()
+        meshnet_config = config[conf().KEY_VALUE_PATH].get('meshnet', {})
+        neighbours = meshnet_config.get('neighbours', {})
+        return [
+            '{}/meshnet/neighbours/{}/'.format(conf().KEY_VALUE_PATH, k)
+            for k, v in neighbours.items() if v[key] == value
+        ]
+    except KeyError as e:
+        log.warning(
+            "Failed to get neighbour key because "
+            "of a KeyError, returning empty list: {}"
+            "".format(e)
+        )
+        return list()
 
 
 # todo: remove this function if it remains unused in the future

--- a/tests/unit/raptiformica/actions/prune/test_del_neighbour_by_key.py
+++ b/tests/unit/raptiformica/actions/prune/test_del_neighbour_by_key.py
@@ -71,3 +71,12 @@ class TestDelNeighbourByKey(TestCase):
         _del_neighbour_by_key('uuid', "not_a_matching_uuid")
 
         self.assertFalse(self.try_delete_config.called)
+
+    def test_del_neighbour_by_key_does_not_throw_exception_if_config_borked(self):
+        self.mapping = {
+            "bork/bork": "bork",
+        }
+        self.get_config.return_value = self.mapping
+
+        # Does not raise
+        _del_neighbour_by_key('uuid', "not_a_matching_uuid")

--- a/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_host.py
+++ b/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_host.py
@@ -56,12 +56,6 @@ class TestGetNeighboursByHost(TestCase):
 
         self.assertCountEqual(ret, tuple())
 
-    def test_get_neighbour_by_host_raises_key_error_if_no_meshnet_configured(self):
-        self.get_config.return_value = {}
-
-        with self.assertRaises(KeyError):
-            get_neighbours_by_host('1.2.3.6')
-
     def test_get_neighbours_by_host_returns_empty_iterable_if_no_neighbours(self):
         self.get_config.return_value = {
             conf().KEY_VALUE_PATH: {

--- a/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
+++ b/tests/unit/raptiformica/actions/prune/test_get_neighbours_by_uuid.py
@@ -53,12 +53,6 @@ class TestGetNeighboursByUuid(TestCase):
 
         self.assertCountEqual(ret, tuple())
 
-    def test_get_neighbour_by_uuid_raises_key_error_if_no_meshnet_configured(self):
-        self.get_config.return_value = {}
-
-        with self.assertRaises(KeyError):
-            get_neighbours_by_uuid('eb442c6170694b12b277c9e88d714cf2')
-
     def test_get_neighbours_by_uuid_returns_empty_iterable_if_no_neighbours(self):
         self.get_config.return_value = {
             conf().KEY_VALUE_PATH: {


### PR DESCRIPTION
to fix:
```
[root@hypervisor53 ~]# raptiformica destroy
Sending shutdown to all connected
Destroying all locally bound instances
Cleaning up stale instance in /root/.raptiformica.d/var/machines/docker/headless/6a3f6df3b1c844bdbb5038402fab2119
Traceback (most recent call last):
  File "/usr/share/raptiformica/bin/raptiformica_destroy.py", line 5, in <module>
    destroy()
  File "/usr/share/raptiformica/raptiformica/cli.py", line 461, in destroy
    purge_artifacts=args.purge_artifacts, purge_modules=args.purge_modules
  File "/usr/share/raptiformica/raptiformica/actions/destroy.py", line 37, in destroy_cluster
    prune_local_machines(force=True)
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 266, in prune_local_machines
    fire_clean_up_triggers(clean_up_triggers, force=force)
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 255, in fire_clean_up_triggers
    ensure_neighbour_removed_from_config_by_uuid(uuid)
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 228, in ensure_neighbour_removed_from_config_by_uuid
    _del_neighbour_by_key('uuid', uuid)
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 214, in _del_neighbour_by_key
    neighbour_keys = _get_neighbour_by_key(key, value)
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 180, in _get_neighbour_by_key
    for k, v in neighbours.items() if v[key] == value
  File "/usr/share/raptiformica/raptiformica/actions/prune.py", line 180, in <listcomp>
    for k, v in neighbours.items() if v[key] == value
KeyError: 'uuid'
```